### PR TITLE
Implement CRUD operations for progress tracking

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/CardProgressController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/CardProgressController.java
@@ -1,0 +1,64 @@
+package com.joeljebitto.SpacedIn.Controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.joeljebitto.SpacedIn.DTO.CardProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.CardProgressResponse;
+import com.joeljebitto.SpacedIn.Service.CardProgressService;
+import com.joeljebitto.SpacedIn.Service.CustomUserDetails;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/cards/{cardId}/progress")
+public class CardProgressController {
+
+  private final CardProgressService service;
+
+  public CardProgressController(CardProgressService service) {
+    this.service = service;
+  }
+
+  @PostMapping
+  public ResponseEntity<CardProgressResponse> createProgress(
+      @PathVariable Long cardId,
+      @Valid @RequestBody CardProgressRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    CardProgressResponse created = service.createProgress(cardId, request, user.getId());
+    return new ResponseEntity<>(created, HttpStatus.CREATED);
+  }
+
+  @GetMapping
+  public ResponseEntity<CardProgressResponse> getProgress(
+      @PathVariable Long cardId,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getProgress(cardId, user.getId()));
+  }
+
+  @PutMapping
+  public ResponseEntity<CardProgressResponse> updateProgress(
+      @PathVariable Long cardId,
+      @Valid @RequestBody CardProgressRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.updateProgress(cardId, request, user.getId()));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<Void> deleteProgress(
+      @PathVariable Long cardId,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    service.deleteProgress(cardId, user.getId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<List<CardProgressResponse>> getUserProgress(
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getProgressForUser(user.getId()));
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/DeckProgressController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/DeckProgressController.java
@@ -1,0 +1,64 @@
+package com.joeljebitto.SpacedIn.Controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.joeljebitto.SpacedIn.DTO.DeckProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.DeckProgressResponse;
+import com.joeljebitto.SpacedIn.Service.CustomUserDetails;
+import com.joeljebitto.SpacedIn.Service.DeckProgressService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/decks/{deckId}/progress")
+public class DeckProgressController {
+
+  private final DeckProgressService service;
+
+  public DeckProgressController(DeckProgressService service) {
+    this.service = service;
+  }
+
+  @PostMapping
+  public ResponseEntity<DeckProgressResponse> createProgress(
+      @PathVariable Long deckId,
+      @Valid @RequestBody DeckProgressRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    DeckProgressResponse created = service.createProgress(deckId, request, user.getId());
+    return new ResponseEntity<>(created, HttpStatus.CREATED);
+  }
+
+  @GetMapping
+  public ResponseEntity<DeckProgressResponse> getProgress(
+      @PathVariable Long deckId,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getProgress(deckId, user.getId()));
+  }
+
+  @PutMapping
+  public ResponseEntity<DeckProgressResponse> updateProgress(
+      @PathVariable Long deckId,
+      @Valid @RequestBody DeckProgressRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.updateProgress(deckId, request, user.getId()));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<Void> deleteProgress(
+      @PathVariable Long deckId,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    service.deleteProgress(deckId, user.getId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<List<DeckProgressResponse>> getUserProgress(
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getProgressForUser(user.getId()));
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/LearningLogController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/LearningLogController.java
@@ -1,0 +1,65 @@
+package com.joeljebitto.SpacedIn.Controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.joeljebitto.SpacedIn.DTO.LearningLogRequest;
+import com.joeljebitto.SpacedIn.DTO.LearningLogResponse;
+import com.joeljebitto.SpacedIn.Service.CustomUserDetails;
+import com.joeljebitto.SpacedIn.Service.LearningLogService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/cards/{cardId}/logs")
+public class LearningLogController {
+
+  private final LearningLogService service;
+
+  public LearningLogController(LearningLogService service) {
+    this.service = service;
+  }
+
+  @PostMapping
+  public ResponseEntity<LearningLogResponse> createLog(
+      @PathVariable Long cardId,
+      @Valid @RequestBody LearningLogRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    LearningLogResponse created = service.createLog(cardId, request, user.getId());
+    return new ResponseEntity<>(created, HttpStatus.CREATED);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<LearningLogResponse>> listLogs(
+      @PathVariable Long cardId,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getLogsForCard(cardId, user.getId()));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<LearningLogResponse> getLog(
+      @PathVariable Long id,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.getLogById(id, user.getId()));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<LearningLogResponse> updateLog(
+      @PathVariable Long id,
+      @Valid @RequestBody LearningLogRequest request,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    return ResponseEntity.ok(service.updateLog(id, request, user.getId()));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteLog(
+      @PathVariable Long id,
+      @AuthenticationPrincipal CustomUserDetails user) {
+    service.deleteLog(id, user.getId());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/SimpleCardController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Controller/SimpleCardController.java
@@ -1,0 +1,73 @@
+package com.joeljebitto.SpacedIn.Controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.joeljebitto.SpacedIn.DTO.SimpleCardRequest;
+import com.joeljebitto.SpacedIn.DTO.SimpleCardResponse;
+import com.joeljebitto.SpacedIn.Service.CustomUserDetails;
+import com.joeljebitto.SpacedIn.Service.SimpleCardService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/decks/{deckId}/cards")
+public class SimpleCardController {
+
+  private final SimpleCardService cardService;
+
+  public SimpleCardController(SimpleCardService cardService) {
+    this.cardService = cardService;
+  }
+
+  // CREATE
+  @PostMapping
+  public ResponseEntity<SimpleCardResponse> addCard(
+      @PathVariable Long deckId,
+      @Valid @RequestBody SimpleCardRequest req,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    SimpleCardResponse created = cardService.createCard(deckId, req, userDetails.getId());
+    return new ResponseEntity<>(created, HttpStatus.CREATED);
+  }
+
+  // READ ALL FOR DECK
+  @GetMapping
+  public ResponseEntity<List<SimpleCardResponse>> listCards(
+      @PathVariable Long deckId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(cardService.getCardsForDeck(deckId, userDetails.getId()));
+  }
+
+  // READ ONE
+  @GetMapping("/{id}")
+  public ResponseEntity<SimpleCardResponse> getCard(
+      @PathVariable Long deckId,
+      @PathVariable Long id,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(cardService.getCardById(deckId, id, userDetails.getId()));
+  }
+
+  // UPDATE
+  @PutMapping("/{id}")
+  public ResponseEntity<SimpleCardResponse> updateCard(
+      @PathVariable Long deckId,
+      @PathVariable Long id,
+      @Valid @RequestBody SimpleCardRequest req,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(cardService.updateCard(deckId, id, req, userDetails.getId()));
+  }
+
+  // DELETE
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteCard(
+      @PathVariable Long deckId,
+      @PathVariable Long id,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    cardService.deleteCard(deckId, id, userDetails.getId());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/CardProgressRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/CardProgressRequest.java
@@ -1,0 +1,17 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public class CardProgressRequest {
+  @NotNull
+  private BigDecimal progress;
+
+  public BigDecimal getProgress() {
+    return progress;
+  }
+
+  public void setProgress(BigDecimal progress) {
+    this.progress = progress;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/CardProgressResponse.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/CardProgressResponse.java
@@ -1,0 +1,33 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import java.math.BigDecimal;
+
+public class CardProgressResponse {
+  private Long id;
+  private BigDecimal progress;
+  private Long cardId;
+  private Long userId;
+
+  public CardProgressResponse(Long id, BigDecimal progress, Long cardId, Long userId) {
+    this.id = id;
+    this.progress = progress;
+    this.cardId = cardId;
+    this.userId = userId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public BigDecimal getProgress() {
+    return progress;
+  }
+
+  public Long getCardId() {
+    return cardId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/DeckProgressRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/DeckProgressRequest.java
@@ -1,0 +1,17 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public class DeckProgressRequest {
+  @NotNull
+  private BigDecimal progress;
+
+  public BigDecimal getProgress() {
+    return progress;
+  }
+
+  public void setProgress(BigDecimal progress) {
+    this.progress = progress;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/DeckProgressResponse.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/DeckProgressResponse.java
@@ -1,0 +1,33 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import java.math.BigDecimal;
+
+public class DeckProgressResponse {
+  private Long id;
+  private BigDecimal progress;
+  private Long deckId;
+  private Long userId;
+
+  public DeckProgressResponse(Long id, BigDecimal progress, Long deckId, Long userId) {
+    this.id = id;
+    this.progress = progress;
+    this.deckId = deckId;
+    this.userId = userId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public BigDecimal getProgress() {
+    return progress;
+  }
+
+  public Long getDeckId() {
+    return deckId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/LearningLogRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/LearningLogRequest.java
@@ -1,0 +1,16 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import jakarta.validation.constraints.NotNull;
+
+public class LearningLogRequest {
+  @NotNull
+  private Boolean status;
+
+  public Boolean getStatus() {
+    return status;
+  }
+
+  public void setStatus(Boolean status) {
+    this.status = status;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/LearningLogResponse.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/LearningLogResponse.java
@@ -1,0 +1,39 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import java.time.LocalDateTime;
+
+public class LearningLogResponse {
+  private Long id;
+  private Boolean status;
+  private LocalDateTime eventTime;
+  private Long cardId;
+  private Long userId;
+
+  public LearningLogResponse(Long id, Boolean status, LocalDateTime eventTime, Long cardId, Long userId) {
+    this.id = id;
+    this.status = status;
+    this.eventTime = eventTime;
+    this.cardId = cardId;
+    this.userId = userId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Boolean getStatus() {
+    return status;
+  }
+
+  public LocalDateTime getEventTime() {
+    return eventTime;
+  }
+
+  public Long getCardId() {
+    return cardId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/SimpleCardRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/SimpleCardRequest.java
@@ -1,0 +1,26 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SimpleCardRequest {
+  @NotBlank
+  private String front;
+  @NotBlank
+  private String back;
+
+  public String getFront() {
+    return front;
+  }
+
+  public void setFront(String front) {
+    this.front = front;
+  }
+
+  public String getBack() {
+    return back;
+  }
+
+  public void setBack(String back) {
+    this.back = back;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/SimpleCardResponse.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/DTO/SimpleCardResponse.java
@@ -1,0 +1,31 @@
+package com.joeljebitto.SpacedIn.DTO;
+
+public class SimpleCardResponse {
+  private Long id;
+  private String front;
+  private String back;
+  private Long deckId;
+
+  public SimpleCardResponse(Long id, String front, String back, Long deckId) {
+    this.id = id;
+    this.front = front;
+    this.back = back;
+    this.deckId = deckId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getFront() {
+    return front;
+  }
+
+  public String getBack() {
+    return back;
+  }
+
+  public Long getDeckId() {
+    return deckId;
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/CardProgressService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/CardProgressService.java
@@ -1,0 +1,18 @@
+package com.joeljebitto.SpacedIn.Service;
+
+import java.util.List;
+
+import com.joeljebitto.SpacedIn.DTO.CardProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.CardProgressResponse;
+
+public interface CardProgressService {
+  CardProgressResponse createProgress(Long cardId, CardProgressRequest request, Long userId);
+
+  CardProgressResponse getProgress(Long cardId, Long userId);
+
+  CardProgressResponse updateProgress(Long cardId, CardProgressRequest request, Long userId);
+
+  void deleteProgress(Long cardId, Long userId);
+
+  List<CardProgressResponse> getProgressForUser(Long userId);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/DeckProgressService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/DeckProgressService.java
@@ -1,0 +1,18 @@
+package com.joeljebitto.SpacedIn.Service;
+
+import java.util.List;
+
+import com.joeljebitto.SpacedIn.DTO.DeckProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.DeckProgressResponse;
+
+public interface DeckProgressService {
+  DeckProgressResponse createProgress(Long deckId, DeckProgressRequest request, Long userId);
+
+  DeckProgressResponse getProgress(Long deckId, Long userId);
+
+  DeckProgressResponse updateProgress(Long deckId, DeckProgressRequest request, Long userId);
+
+  void deleteProgress(Long deckId, Long userId);
+
+  List<DeckProgressResponse> getProgressForUser(Long userId);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/LearningLogService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/LearningLogService.java
@@ -1,0 +1,18 @@
+package com.joeljebitto.SpacedIn.Service;
+
+import java.util.List;
+
+import com.joeljebitto.SpacedIn.DTO.LearningLogRequest;
+import com.joeljebitto.SpacedIn.DTO.LearningLogResponse;
+
+public interface LearningLogService {
+  LearningLogResponse createLog(Long cardId, LearningLogRequest request, Long userId);
+
+  List<LearningLogResponse> getLogsForCard(Long cardId, Long userId);
+
+  LearningLogResponse getLogById(Long id, Long userId);
+
+  LearningLogResponse updateLog(Long id, LearningLogRequest request, Long userId);
+
+  void deleteLog(Long id, Long userId);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/SimpleCardService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/SimpleCardService.java
@@ -1,0 +1,18 @@
+package com.joeljebitto.SpacedIn.Service;
+
+import java.util.List;
+
+import com.joeljebitto.SpacedIn.DTO.SimpleCardRequest;
+import com.joeljebitto.SpacedIn.DTO.SimpleCardResponse;
+
+public interface SimpleCardService {
+  SimpleCardResponse createCard(Long deckId, SimpleCardRequest request, Long userId);
+
+  List<SimpleCardResponse> getCardsForDeck(Long deckId, Long userId);
+
+  SimpleCardResponse getCardById(Long deckId, Long cardId, Long userId);
+
+  SimpleCardResponse updateCard(Long deckId, Long cardId, SimpleCardRequest request, Long userId);
+
+  void deleteCard(Long deckId, Long cardId, Long userId);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/CardProgressServiceImpl.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/CardProgressServiceImpl.java
@@ -1,0 +1,99 @@
+package com.joeljebitto.SpacedIn.Service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joeljebitto.SpacedIn.DTO.CardProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.CardProgressResponse;
+import com.joeljebitto.SpacedIn.Entity.Card;
+import com.joeljebitto.SpacedIn.Entity.CardProgress;
+import com.joeljebitto.SpacedIn.Entity.User;
+import com.joeljebitto.SpacedIn.Repository.CardProgressRepository;
+import com.joeljebitto.SpacedIn.Repository.CardRepository;
+import com.joeljebitto.SpacedIn.Repository.UserRepository;
+import com.joeljebitto.SpacedIn.Service.CardProgressService;
+import com.joeljebitto.SpacedIn.exception.ResourceNotFoundException;
+
+@Service
+@Transactional
+public class CardProgressServiceImpl implements CardProgressService {
+
+  private final CardProgressRepository progressRepo;
+  private final CardRepository cardRepo;
+  private final UserRepository userRepo;
+
+  public CardProgressServiceImpl(CardProgressRepository progressRepo,
+      CardRepository cardRepo,
+      UserRepository userRepo) {
+    this.progressRepo = progressRepo;
+    this.cardRepo = cardRepo;
+    this.userRepo = userRepo;
+  }
+
+  @Override
+  public CardProgressResponse createProgress(Long cardId, CardProgressRequest request, Long userId) {
+    Card card = cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    CardProgress progress = progressRepo.findByUserIdAndCardId(userId, cardId);
+    if (progress == null) {
+      User user = userRepo.findById(userId)
+          .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+      progress = new CardProgress(card, user, request.getProgress());
+    } else {
+      progress.setProgress(request.getProgress());
+    }
+    CardProgress saved = progressRepo.save(progress);
+    return toResponse(saved);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public CardProgressResponse getProgress(Long cardId, Long userId) {
+    CardProgress progress = progressRepo.findByUserIdAndCardId(userId, cardId);
+    if (progress == null) {
+      throw new ResourceNotFoundException("CardProgress", "cardId", cardId);
+    }
+    return toResponse(progress);
+  }
+
+  @Override
+  public CardProgressResponse updateProgress(Long cardId, CardProgressRequest request, Long userId) {
+    CardProgress progress = progressRepo.findByUserIdAndCardId(userId, cardId);
+    if (progress == null) {
+      throw new ResourceNotFoundException("CardProgress", "cardId", cardId);
+    }
+    progress.setProgress(request.getProgress());
+    CardProgress saved = progressRepo.save(progress);
+    return toResponse(saved);
+  }
+
+  @Override
+  public void deleteProgress(Long cardId, Long userId) {
+    CardProgress progress = progressRepo.findByUserIdAndCardId(userId, cardId);
+    if (progress != null) {
+      progressRepo.delete(progress);
+    }
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<CardProgressResponse> getProgressForUser(Long userId) {
+    return progressRepo.findByUserId(userId).stream()
+        .map(this::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  private CardProgressResponse toResponse(CardProgress progress) {
+    return new CardProgressResponse(
+        progress.getId(),
+        progress.getProgress(),
+        progress.getCard().getId(),
+        progress.getUser().getId());
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/DeckProgressServiceImpl.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/DeckProgressServiceImpl.java
@@ -1,0 +1,96 @@
+package com.joeljebitto.SpacedIn.Service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joeljebitto.SpacedIn.DTO.DeckProgressRequest;
+import com.joeljebitto.SpacedIn.DTO.DeckProgressResponse;
+import com.joeljebitto.SpacedIn.Entity.Deck;
+import com.joeljebitto.SpacedIn.Entity.DeckProgress;
+import com.joeljebitto.SpacedIn.Entity.User;
+import com.joeljebitto.SpacedIn.Repository.DeckProgressRepository;
+import com.joeljebitto.SpacedIn.Repository.DeckRepository;
+import com.joeljebitto.SpacedIn.Repository.UserRepository;
+import com.joeljebitto.SpacedIn.Service.DeckProgressService;
+import com.joeljebitto.SpacedIn.exception.ResourceNotFoundException;
+
+@Service
+@Transactional
+public class DeckProgressServiceImpl implements DeckProgressService {
+
+  private final DeckProgressRepository progressRepo;
+  private final DeckRepository deckRepo;
+  private final UserRepository userRepo;
+
+  public DeckProgressServiceImpl(DeckProgressRepository progressRepo,
+      DeckRepository deckRepo,
+      UserRepository userRepo) {
+    this.progressRepo = progressRepo;
+    this.deckRepo = deckRepo;
+    this.userRepo = userRepo;
+  }
+
+  @Override
+  public DeckProgressResponse createProgress(Long deckId, DeckProgressRequest request, Long userId) {
+    Deck deck = deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+    DeckProgress progress = progressRepo.findByUserIdAndDeckId(userId, deckId);
+    if (progress == null) {
+      User user = userRepo.findById(userId)
+          .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+      progress = new DeckProgress(deck, user, request.getProgress());
+    } else {
+      progress.setProgress(request.getProgress());
+    }
+    DeckProgress saved = progressRepo.save(progress);
+    return toResponse(saved);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public DeckProgressResponse getProgress(Long deckId, Long userId) {
+    DeckProgress progress = progressRepo.findByUserIdAndDeckId(userId, deckId);
+    if (progress == null) {
+      throw new ResourceNotFoundException("DeckProgress", "deckId", deckId);
+    }
+    return toResponse(progress);
+  }
+
+  @Override
+  public DeckProgressResponse updateProgress(Long deckId, DeckProgressRequest request, Long userId) {
+    DeckProgress progress = progressRepo.findByUserIdAndDeckId(userId, deckId);
+    if (progress == null) {
+      throw new ResourceNotFoundException("DeckProgress", "deckId", deckId);
+    }
+    progress.setProgress(request.getProgress());
+    DeckProgress saved = progressRepo.save(progress);
+    return toResponse(saved);
+  }
+
+  @Override
+  public void deleteProgress(Long deckId, Long userId) {
+    DeckProgress progress = progressRepo.findByUserIdAndDeckId(userId, deckId);
+    if (progress != null) {
+      progressRepo.delete(progress);
+    }
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<DeckProgressResponse> getProgressForUser(Long userId) {
+    return progressRepo.findByUserId(userId).stream()
+        .map(this::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  private DeckProgressResponse toResponse(DeckProgress progress) {
+    return new DeckProgressResponse(
+        progress.getId(),
+        progress.getProgress(),
+        progress.getDeck().getId(),
+        progress.getUser().getId());
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/LearningLogServiceImpl.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/LearningLogServiceImpl.java
@@ -1,0 +1,105 @@
+package com.joeljebitto.SpacedIn.Service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joeljebitto.SpacedIn.DTO.LearningLogRequest;
+import com.joeljebitto.SpacedIn.DTO.LearningLogResponse;
+import com.joeljebitto.SpacedIn.Entity.Card;
+import com.joeljebitto.SpacedIn.Entity.LearningLog;
+import com.joeljebitto.SpacedIn.Entity.User;
+import com.joeljebitto.SpacedIn.Repository.CardRepository;
+import com.joeljebitto.SpacedIn.Repository.LearningLogRepository;
+import com.joeljebitto.SpacedIn.Repository.UserRepository;
+import com.joeljebitto.SpacedIn.Service.LearningLogService;
+import com.joeljebitto.SpacedIn.exception.ResourceNotFoundException;
+
+@Service
+@Transactional
+public class LearningLogServiceImpl implements LearningLogService {
+
+  private final LearningLogRepository logRepo;
+  private final CardRepository cardRepo;
+  private final UserRepository userRepo;
+
+  public LearningLogServiceImpl(LearningLogRepository logRepo,
+      CardRepository cardRepo,
+      UserRepository userRepo) {
+    this.logRepo = logRepo;
+    this.cardRepo = cardRepo;
+    this.userRepo = userRepo;
+  }
+
+  @Override
+  public LearningLogResponse createLog(Long cardId, LearningLogRequest request, Long userId) {
+    Card card = cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    User user = userRepo.findById(userId)
+        .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+    LearningLog log = new LearningLog(card, user, request.getStatus());
+    LearningLog saved = logRepo.save(log);
+    return toResponse(saved);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<LearningLogResponse> getLogsForCard(Long cardId, Long userId) {
+    Card card = cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    return logRepo.findByCardId(cardId).stream()
+        .filter(l -> l.getUser().getId().equals(userId))
+        .map(this::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public LearningLogResponse getLogById(Long id, Long userId) {
+    LearningLog log = logRepo.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("LearningLog", "id", id));
+    if (!log.getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("LearningLog", "id", id);
+    }
+    return toResponse(log);
+  }
+
+  @Override
+  public LearningLogResponse updateLog(Long id, LearningLogRequest request, Long userId) {
+    LearningLog log = logRepo.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("LearningLog", "id", id));
+    if (!log.getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("LearningLog", "id", id);
+    }
+    log.setStatus(request.getStatus());
+    LearningLog saved = logRepo.save(log);
+    return toResponse(saved);
+  }
+
+  @Override
+  public void deleteLog(Long id, Long userId) {
+    LearningLog log = logRepo.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("LearningLog", "id", id));
+    if (!log.getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("LearningLog", "id", id);
+    }
+    logRepo.delete(log);
+  }
+
+  private LearningLogResponse toResponse(LearningLog log) {
+    return new LearningLogResponse(
+        log.getId(),
+        log.getStatus(),
+        log.getEventTime(),
+        log.getCard().getId(),
+        log.getUser().getId());
+  }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/SimpleCardServiceImpl.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Service/impl/SimpleCardServiceImpl.java
@@ -1,0 +1,102 @@
+package com.joeljebitto.SpacedIn.Service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joeljebitto.SpacedIn.DTO.SimpleCardRequest;
+import com.joeljebitto.SpacedIn.DTO.SimpleCardResponse;
+import com.joeljebitto.SpacedIn.Entity.Deck;
+import com.joeljebitto.SpacedIn.Entity.SimpleCard;
+import com.joeljebitto.SpacedIn.Repository.DeckRepository;
+import com.joeljebitto.SpacedIn.Repository.SimpleCardRepository;
+import com.joeljebitto.SpacedIn.Service.SimpleCardService;
+import com.joeljebitto.SpacedIn.exception.ResourceNotFoundException;
+
+@Service
+@Transactional
+public class SimpleCardServiceImpl implements SimpleCardService {
+
+  private final DeckRepository deckRepo;
+  private final SimpleCardRepository cardRepo;
+
+  public SimpleCardServiceImpl(DeckRepository deckRepo, SimpleCardRepository cardRepo) {
+    this.deckRepo = deckRepo;
+    this.cardRepo = cardRepo;
+  }
+
+  @Override
+  public SimpleCardResponse createCard(Long deckId, SimpleCardRequest request, Long userId) {
+    Deck deck = deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+
+    SimpleCard card = new SimpleCard();
+    card.setDeck(deck);
+    card.setType("SimpleCard");
+    card.setFront(request.getFront());
+    card.setBack(request.getBack());
+
+    SimpleCard saved = cardRepo.save(card);
+    return toResponse(saved);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<SimpleCardResponse> getCardsForDeck(Long deckId, Long userId) {
+    deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+    return cardRepo.findByDeckId(deckId).stream()
+        .map(this::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public SimpleCardResponse getCardById(Long deckId, Long cardId, Long userId) {
+    Deck deck = deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+    SimpleCard card = (SimpleCard) cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getId().equals(deck.getId())) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    return toResponse(card);
+  }
+
+  @Override
+  public SimpleCardResponse updateCard(Long deckId, Long cardId, SimpleCardRequest request, Long userId) {
+    Deck deck = deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+    SimpleCard card = (SimpleCard) cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getId().equals(deck.getId())) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    card.setFront(request.getFront());
+    card.setBack(request.getBack());
+    SimpleCard updated = cardRepo.save(card);
+    return toResponse(updated);
+  }
+
+  @Override
+  public void deleteCard(Long deckId, Long cardId, Long userId) {
+    Deck deck = deckRepo.findByIdAndUserId(deckId, userId)
+        .orElseThrow(() -> new ResourceNotFoundException("Deck", "id", deckId));
+    SimpleCard card = (SimpleCard) cardRepo.findById(cardId)
+        .orElseThrow(() -> new ResourceNotFoundException("Card", "id", cardId));
+    if (!card.getDeck().getId().equals(deck.getId())) {
+      throw new ResourceNotFoundException("Card", "id", cardId);
+    }
+    cardRepo.delete(card);
+  }
+
+  private SimpleCardResponse toResponse(SimpleCard card) {
+    return new SimpleCardResponse(
+        card.getId(),
+        card.getFront(),
+        card.getBack(),
+        card.getDeck().getId());
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD endpoints for card progress, deck progress, and learning logs
- implement corresponding services and DTOs

## Testing
- `./Server/mvnw -q -f Server/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6860bdc25f68832d86b17cb122a4656e