### PR TITLE
Finish frontend components

### DIFF
--- a/SpacedIn/src/App.jsx
+++ b/SpacedIn/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/" element={<Landing />} />
-          <Route path="/deck" element={<Deck />} />
+          <Route path="/deck/:id" element={<Deck />} />
           <Route path="/dashboard" element={<Dashboard />} />
         </Route>
       </Routes>

--- a/SpacedIn/src/components/AddCardButton.jsx
+++ b/SpacedIn/src/components/AddCardButton.jsx
@@ -1,24 +1,72 @@
-function AddCardButton({ className }) {
+import { useState, useRef } from "react";
+import useCardStore from "../store/useCardStore";
+
+function AddCardButton({ deckId, className }) {
+  const [open, setOpen] = useState(false);
+  const front = useRef();
+  const back = useRef();
+  const { createCard } = useCardStore();
+
+  const handleCreate = () => {
+    createCard(deckId, front.current.value, back.current.value);
+    setOpen(false);
+  };
+
   return (
-    <button
-      className={`bg-green-700 p-5 shadow-2xl mt-3 flex justify-center rounded-2xl text-gray-200 font-bold active:bg-green-500 hover:bg-green-600 ${className}`}
-    >
-      Add Card
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={1.5}
-        stroke="currentColor"
-        className="size-6 mx-1"
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className={`bg-green-700 p-5 shadow-2xl mt-3 flex justify-center rounded-2xl text-gray-200 font-bold active:bg-green-500 hover:bg-green-600 ${className}`}
       >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-        />
-      </svg>
-    </button>
+        Add Card
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="size-6 mx-1"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-gray-900 p-6 rounded-xl border border-gray-700 w-full max-w-md shadow-2xl relative">
+            <button
+              onClick={() => setOpen(false)}
+              className="absolute top-2 right-3 text-gray-100 hover:text-red-500 text-xl"
+            >
+              &times;
+            </button>
+            <h2 className="text-lg font-semibold mb-4 text-gray-200">Add New Card</h2>
+            <input
+              ref={front}
+              type="text"
+              placeholder="Front"
+              className="w-full px-4 py-2 mb-3 bg-gray-900 border rounded-md text-white focus:outline-none focus:ring focus:ring-blue-400"
+            />
+            <input
+              ref={back}
+              type="text"
+              placeholder="Back"
+              className="w-full px-4 py-2 mb-3 bg-gray-900 border rounded-md text-white focus:outline-none focus:ring focus:ring-blue-400"
+            />
+            <button
+              className="mt-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              onClick={handleCreate}
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/SpacedIn/src/components/AddDeckButton.jsx
+++ b/SpacedIn/src/components/AddDeckButton.jsx
@@ -7,7 +7,7 @@ export default function AddDeckButton() {
   const name = useRef();
   const { createDeck } = useDeckStore();
   const handleCreateDeck = () => {
-    const e = createDeck(name.current.value);
+    createDeck(name.current.value);
     setOpen(false);
   };
   return (

--- a/SpacedIn/src/components/Card.jsx
+++ b/SpacedIn/src/components/Card.jsx
@@ -1,12 +1,12 @@
 import EditCardButton from "./EditCardButton";
 import LearnButton from "./LearnButton";
 
-const Card = () => {
+const Card = ({ front, back }) => {
   return (
     <div className="bg-black/50 flex flex-col mx-auto my-2 p-5 text-white w-full sm:w-[80%] md:w-[47%] rounded-xl shadow-2xl">
-      <h1 className="text-xl mb-24">value of pie</h1>
-
-      <div className="flex flex-col">
+      <h1 className="text-xl font-semibold mb-2">{front}</h1>
+      <p className="text-gray-300 flex-1 mb-3">{back}</p>
+      <div className="flex flex-col mt-2">
         <EditCardButton className="w-full" />
         <LearnButton className="w-full" />
       </div>

--- a/SpacedIn/src/components/Cards.jsx
+++ b/SpacedIn/src/components/Cards.jsx
@@ -1,14 +1,11 @@
 import Card from "./Card";
 
-const Cards = () => {
+const Cards = ({ cards = [] }) => {
   return (
     <div className="bg-black/80 p-5 flex flex-wrap rounded-xl shadow-2xl mt-10">
-      <Card />
-      <Card />
-      <Card />
-      <Card />
-      <Card />
-      <Card />
+      {cards.map((c) => (
+        <Card key={c.id} {...c} />
+      ))}
     </div>
   );
 };

--- a/SpacedIn/src/components/Deck.jsx
+++ b/SpacedIn/src/components/Deck.jsx
@@ -1,4 +1,5 @@
 import LearnButton from "./LearnButton";
+import { Link } from "react-router-dom";
 
 export default function Deck({ title, description, id, createdOn }) {
   const dateObject = new Date(createdOn);
@@ -11,16 +12,16 @@ export default function Deck({ title, description, id, createdOn }) {
   };
   const formattedDate = dateObject.toLocaleDateString(undefined, options);
   return (
-    <div
+    <Link
+      to={`/deck/${id}`}
       className="bg-black/50 flex flex-col mx-auto my-2 p-5 text-white w-full md:w-[47%] rounded-xl shadow-2xl"
-      key={id}
     >
       <h1 className="text-3xl font-bold">{title}</h1>
       <p className="text-gray-300 text-md">{formattedDate}</p>
-      <hr class="border-2 border-gray-800 my-2 " />
+      <hr className="border-2 border-gray-800 my-2 " />
       <p className="text-gray-100 flex-1 text-lg">{description}</p>
 
       <LearnButton className="mt-20" />
-    </div>
+    </Link>
   );
 }

--- a/SpacedIn/src/components/DeckOverview.jsx
+++ b/SpacedIn/src/components/DeckOverview.jsx
@@ -2,13 +2,13 @@ import AddCardButton from "./AddCardButton";
 import LearnButton from "./LearnButton";
 import ProgressBar from "./ProgressBar";
 
-const DeckOverview = () => {
+const DeckOverview = ({ deckId }) => {
   return (
     <div className="bg-black/80 p-5 flex flex-col rounded-xl shadow-2xl mt-10">
       <ProgressBar val={70} title="Deck Progress" />
       <div className="flex sm:flex-row-reverse flex-col-reverse  sm:pt-5">
         <LearnButton className="w-full sm:w-1/3" />
-        <AddCardButton className="w-full sm:w-1/3 sm:mx-2" />
+        <AddCardButton deckId={deckId} className="w-full sm:w-1/3 sm:mx-2" />
       </div>
     </div>
   );

--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -1,20 +1,41 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import Cards from "../components/Cards";
 import DeckOverview from "../components/DeckOverview";
-// import useCurrentDeckStore from "../store/useCurrentDeckStore";
+import useCardStore from "../store/useCardStore";
 
 const Deck = () => {
-  const deck = {
-    title: "hello",
-    description: "hi",
-  };
+  const { id } = useParams();
+  const [deck, setDeck] = useState(null);
+  const { cards, getCards } = useCardStore();
+
+  useEffect(() => {
+    const fetchDeck = async () => {
+      const token = localStorage.getItem("token");
+      const res = await fetch(`http://localhost:8080/api/v1/decks/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setDeck(data);
+      }
+    };
+    fetchDeck();
+    getCards(id);
+  }, [id, getCards]);
+
+  if (!deck) {
+    return <div className="text-center text-white mt-10">Loading...</div>;
+  }
+
   return (
     <div className="flex flex-col w-screen lg:w-[55rem] m-5 lg:mx-auto">
       <div className="bg-black/80 p-5 flex flex-col rounded-xl shadow-2xl">
         <h1 className="text-white text-4xl font-bold">{deck.title}</h1>
         <p className="text-gray-100">{deck.description}</p>
       </div>
-      <DeckOverview />
-      <Cards />
+      <DeckOverview deckId={id} />
+      <Cards cards={cards} />
     </div>
   );
 };

--- a/SpacedIn/src/pages/Landing.jsx
+++ b/SpacedIn/src/pages/Landing.jsx
@@ -1,3 +1,24 @@
+import { useNavigate } from "react-router-dom";
+
 export default function Landing() {
-  return <div>Landing</div>;
+  const navigate = useNavigate();
+
+  const handleStart = () => {
+    navigate("/signup");
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-40 px-5">
+      <h1 className="text-5xl font-bold text-gray-900 mb-6">Welcome to SpacedIn</h1>
+      <p className="text-gray-800 text-lg mb-8">
+        Master your subjects with spaced repetition.
+      </p>
+      <button
+        onClick={handleStart}
+        className="bg-black text-white px-6 py-3 rounded-xl shadow-2xl hover:bg-gray-800"
+      >
+        Get Started
+      </button>
+    </div>
+  );
 }

--- a/SpacedIn/src/store/useCardStore.jsx
+++ b/SpacedIn/src/store/useCardStore.jsx
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+
+const useCardStore = create((set) => ({
+  cards: [],
+  getCards: async (deckId) => {
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(
+        `http://localhost:8080/api/v1/decks/${deckId}/cards`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      if (!res.ok) throw new Error("Failed to fetch cards");
+      const data = await res.json();
+      set({ cards: data });
+    } catch (error) {
+      console.error(error);
+    }
+  },
+  createCard: async (deckId, front, back) => {
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(
+        `http://localhost:8080/api/v1/decks/${deckId}/cards`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ front, back }),
+        }
+      );
+      if (!res.ok) throw new Error("Failed to create card");
+      const card = await res.json();
+      set((state) => ({ cards: [...state.cards, card] }));
+    } catch (error) {
+      console.error(error);
+    }
+  },
+}));
+
+export default useCardStore;

--- a/SpacedIn/src/store/useDeckStore.jsx
+++ b/SpacedIn/src/store/useDeckStore.jsx
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-const useDeckStore = create((set, get) => ({
+const useDeckStore = create((set) => ({
   // state
   decks: [],
 


### PR DESCRIPTION
## Summary
- build a better landing page
- support dynamic deck routes
- load deck & card data from the API
- allow adding cards in a modal
- improve deck store and add card store

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860c3cc1dec832d953d011142dfae5a