### PR TITLE
Fix deck click navigation

### DIFF
--- a/SpacedIn/src/components/Deck.jsx
+++ b/SpacedIn/src/components/Deck.jsx
@@ -1,5 +1,5 @@
 import LearnButton from "./LearnButton";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Deck({ title, description, id, createdOn }) {
   const dateObject = new Date(createdOn);
@@ -11,10 +11,15 @@ export default function Deck({ title, description, id, createdOn }) {
     weekday: "long",
   };
   const formattedDate = dateObject.toLocaleDateString(undefined, options);
+  const navigate = useNavigate();
+  const handleOpen = () => {
+    navigate(`/deck/${id}`);
+  };
+
   return (
-    <Link
-      to={`/deck/${id}`}
-      className="bg-black/50 flex flex-col mx-auto my-2 p-5 text-white w-full md:w-[47%] rounded-xl shadow-2xl"
+    <div
+      onClick={handleOpen}
+      className="bg-black/50 flex flex-col mx-auto my-2 p-5 text-white w-full md:w-[47%] rounded-xl shadow-2xl cursor-pointer"
     >
       <h1 className="text-3xl font-bold">{title}</h1>
       <p className="text-gray-300 text-md">{formattedDate}</p>
@@ -22,6 +27,6 @@ export default function Deck({ title, description, id, createdOn }) {
       <p className="text-gray-100 flex-1 text-lg">{description}</p>
 
       <LearnButton className="mt-20" />
-    </Link>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add navigation handler for deck cards

## Testing
- `pnpm lint`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c7b02534832d9635ad06c5efd90e