### PR TITLE
Add edit card and deck UI

### DIFF
--- a/SpacedIn/src/components/Card.jsx
+++ b/SpacedIn/src/components/Card.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import EditCardButton from "./EditCardButton";
 import LearnButton from "./LearnButton";
 
-const Card = ({ front, back }) => {
+const Card = ({ id, deckId, front, back }) => {
   const [showBack, setShowBack] = useState(false);
   const toggle = () => setShowBack((s) => !s);
 
@@ -14,7 +14,13 @@ const Card = ({ front, back }) => {
       <h1 className="text-xl font-semibold mb-2">{front}</h1>
       {showBack && <p className="text-gray-300 flex-1 mb-3">{back}</p>}
       <div className="flex flex-col mt-2">
-        <EditCardButton className="w-full" />
+        <EditCardButton
+          deckId={deckId}
+          id={id}
+          front={front}
+          back={back}
+          className="w-full"
+        />
         <LearnButton className="w-full" />
       </div>
     </div>

--- a/SpacedIn/src/components/DeckOverview.jsx
+++ b/SpacedIn/src/components/DeckOverview.jsx
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import AddCardButton from "./AddCardButton";
+import EditDeckButton from "./EditDeckButton";
 import LearnButton from "./LearnButton";
 import ProgressBar from "./ProgressBar";
 import useDeckProgressStore from "../store/useDeckProgressStore";
 
-const DeckOverview = ({ deckId }) => {
+const DeckOverview = ({ deckId, deck }) => {
   const { progressMap, fetchProgress } = useDeckProgressStore();
   useEffect(() => {
     fetchProgress(deckId);
@@ -18,6 +19,9 @@ const DeckOverview = ({ deckId }) => {
       <div className="flex sm:flex-row-reverse flex-col-reverse  sm:pt-5">
         <LearnButton className="w-full sm:w-1/3" />
         <AddCardButton deckId={deckId} className="w-full sm:w-1/3 sm:mx-2" />
+        {deck && (
+          <EditDeckButton deck={deck} className="w-full sm:w-1/3" />
+        )}
       </div>
     </div>
   );

--- a/SpacedIn/src/components/EditDeckButton.jsx
+++ b/SpacedIn/src/components/EditDeckButton.jsx
@@ -1,20 +1,14 @@
-import { useState } from "react";
-import useCardStore from "../store/useCardStore";
+import { useState, useRef } from "react";
+import useDeckStore from "../store/useDeckStore";
 
-export default function EditCardButton({
-  deckId,
-  id,
-  front: initialFront,
-  back: initialBack,
-  className,
-}) {
+export default function EditDeckButton({ deck, className }) {
   const [open, setOpen] = useState(false);
-  const [front, setFront] = useState(initialFront);
-  const [back, setBack] = useState(initialBack);
-  const { updateCard } = useCardStore();
+  const name = useRef();
+  const description = useRef();
+  const { updateDeck } = useDeckStore();
 
-  const handleUpdate = () => {
-    updateCard(deckId, id, front, back);
+  const handleUpdateDeck = async () => {
+    await updateDeck(deck.id, name.current.value, description.current.value);
     setOpen(false);
   };
 
@@ -24,7 +18,7 @@ export default function EditCardButton({
         onClick={() => setOpen(true)}
         className={`bg-orange-700 p-5 shadow-2xl mt-3 flex justify-center rounded-2xl text-gray-200 font-bold active:bg-orange-500 hover:bg-orange-600 ${className}`}
       >
-        Edit Card
+        Edit Deck
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -50,24 +44,23 @@ export default function EditCardButton({
             >
               &times;
             </button>
-            <h2 className="text-lg font-semibold mb-4 text-gray-200">Edit Card</h2>
+            <h2 className="text-lg font-semibold mb-4 text-gray-200 ">Edit Deck</h2>
             <input
-              value={front}
-              onChange={(e) => setFront(e.target.value)}
+              ref={name}
+              defaultValue={deck.title}
               type="text"
-              placeholder="Front"
-              className="w-full px-4 py-2 mb-3 bg-gray-900 border rounded-md text-white focus:outline-none focus:ring focus:ring-blue-400"
+              placeholder="Deck name"
+              className="w-full px-4 py-2 mb-3 border rounded-md focus:outline-none bg-gray-900 text-white focus:ring focus:ring-blue-400 "
             />
-            <input
-              value={back}
-              onChange={(e) => setBack(e.target.value)}
-              type="text"
-              placeholder="Back"
-              className="w-full px-4 py-2 mb-3 bg-gray-900 border rounded-md text-white focus:outline-none focus:ring focus:ring-blue-400"
+            <textarea
+              ref={description}
+              defaultValue={deck.description}
+              placeholder="Description"
+              className="w-full px-4 py-2 mb-3 border rounded-md focus:outline-none bg-gray-900 text-white focus:ring focus:ring-blue-400"
             />
             <button
-              className="mt-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-              onClick={handleUpdate}
+              className="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              onClick={handleUpdateDeck}
             >
               Save
             </button>

--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -34,7 +34,7 @@ const Deck = () => {
         <h1 className="text-white text-4xl font-bold">{deck.title}</h1>
         <p className="text-gray-100">{deck.description}</p>
       </div>
-      <DeckOverview deckId={id} />
+      <DeckOverview deckId={id} deck={deck} />
       <Cards cards={cards} />
     </div>
   );

--- a/SpacedIn/src/store/useCardStore.jsx
+++ b/SpacedIn/src/store/useCardStore.jsx
@@ -43,6 +43,29 @@ const useCardStore = create((set) => ({
       console.error(error);
     }
   },
+  updateCard: async (deckId, id, front, back) => {
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(
+        `http://localhost:8080/api/v1/decks/${deckId}/cards/${id}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ front, back }),
+        }
+      );
+      if (!res.ok) throw new Error("Failed to update card");
+      const updated = await res.json();
+      set((state) => ({
+        cards: state.cards.map((c) => (c.id === id ? updated : c)),
+      }));
+    } catch (error) {
+      console.error(error);
+    }
+  },
 }));
 
 export default useCardStore;


### PR DESCRIPTION
## Summary
- support card update in store
- add edit card modal button
- add edit deck modal button
- wire edit buttons into deck and card components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686128803368832da795308400de8d26