### PR TITLE
Fix progress 403 and refresh deck

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Config/SecurityConfig.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -34,6 +35,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .cors(Customizer.withDefaults())
         .authorizeHttpRequests(auth -> auth
+            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .requestMatchers("/api/v1/auth/**").permitAll()
             .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/Utils/JwtAuthFilter.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/Utils/JwtAuthFilter.java
@@ -27,13 +27,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
   private CustomUserDetailsService userDetailsService;
 
   /**
-   * Don’t run the filter on auth endpoints.
+   * Skip filtering for auth endpoints and CORS pre-flight requests.
    */
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
     String path = request.getServletPath();
-    // adjust these to match your auth endpoints
-    return path.startsWith("/api/v1/auth");
+    // Skip auth paths and OPTIONS preflight requests
+    return "OPTIONS".equalsIgnoreCase(request.getMethod()) || path.startsWith("/api/v1/auth");
   }
 
   @Override

--- a/SpacedIn/src/components/DeckOverview.jsx
+++ b/SpacedIn/src/components/DeckOverview.jsx
@@ -5,7 +5,7 @@ import LearnButton from "./LearnButton";
 import ProgressBar from "./ProgressBar";
 import useDeckProgressStore from "../store/useDeckProgressStore";
 
-const DeckOverview = ({ deckId, deck }) => {
+const DeckOverview = ({ deckId, deck, onDeckUpdated }) => {
   const { progressMap, fetchProgress } = useDeckProgressStore();
   useEffect(() => {
     fetchProgress(deckId);
@@ -20,7 +20,11 @@ const DeckOverview = ({ deckId, deck }) => {
         <LearnButton className="w-full sm:w-1/3" />
         <AddCardButton deckId={deckId} className="w-full sm:w-1/3 sm:mx-2" />
         {deck && (
-          <EditDeckButton deck={deck} className="w-full sm:w-1/3" />
+          <EditDeckButton
+            deck={deck}
+            onUpdated={onDeckUpdated}
+            className="w-full sm:w-1/3"
+          />
         )}
       </div>
     </div>

--- a/SpacedIn/src/components/EditDeckButton.jsx
+++ b/SpacedIn/src/components/EditDeckButton.jsx
@@ -1,14 +1,21 @@
 import { useState, useRef } from "react";
 import useDeckStore from "../store/useDeckStore";
 
-export default function EditDeckButton({ deck, className }) {
+export default function EditDeckButton({ deck, className, onUpdated }) {
   const [open, setOpen] = useState(false);
   const name = useRef();
   const description = useRef();
   const { updateDeck } = useDeckStore();
 
   const handleUpdateDeck = async () => {
-    await updateDeck(deck.id, name.current.value, description.current.value);
+    const updated = await updateDeck(
+      deck.id,
+      name.current.value,
+      description.current.value,
+    );
+    if (updated && onUpdated) {
+      onUpdated(updated);
+    }
     setOpen(false);
   };
 

--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -9,17 +9,18 @@ const Deck = () => {
   const [deck, setDeck] = useState(null);
   const { cards, getCards } = useCardStore();
 
+  const fetchDeck = async () => {
+    const token = localStorage.getItem("token");
+    const res = await fetch(`http://localhost:8080/api/v1/decks/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setDeck(data);
+    }
+  };
+
   useEffect(() => {
-    const fetchDeck = async () => {
-      const token = localStorage.getItem("token");
-      const res = await fetch(`http://localhost:8080/api/v1/decks/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setDeck(data);
-      }
-    };
     fetchDeck();
     getCards(id);
   }, [id, getCards]);
@@ -34,7 +35,7 @@ const Deck = () => {
         <h1 className="text-white text-4xl font-bold">{deck.title}</h1>
         <p className="text-gray-100">{deck.description}</p>
       </div>
-      <DeckOverview deckId={id} deck={deck} />
+      <DeckOverview deckId={id} deck={deck} onDeckUpdated={fetchDeck} />
       <Cards cards={cards} />
     </div>
   );

--- a/SpacedIn/src/store/useDeckStore.jsx
+++ b/SpacedIn/src/store/useDeckStore.jsx
@@ -69,8 +69,10 @@ const useDeckStore = create((set) => ({
       set((state) => ({
         decks: state.decks.map((d) => (d.id === id ? updated : d)),
       }));
+      return updated;
     } catch (error) {
       console.error(error);
+      return null;
     }
   },
 


### PR DESCRIPTION
## Summary
- allow OPTIONS requests in security configuration and skip auth filter for pre-flight
- notify parent component after editing deck so Deck refreshes

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_686135e2566c832d8d7d9bf061ee6d7c