### PR TITLE
Implement basic auth and deck features

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AuthController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.joeljebitto.SpacedIn.controller;
+
+import com.joeljebitto.SpacedIn.dto.AuthResponse;
+import com.joeljebitto.SpacedIn.dto.LoginRequest;
+import com.joeljebitto.SpacedIn.dto.RegisterRequest;
+import com.joeljebitto.SpacedIn.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody RegisterRequest request) {
+        authService.register(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/DeckController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/DeckController.java
@@ -1,0 +1,29 @@
+package com.joeljebitto.SpacedIn.controller;
+
+import com.joeljebitto.SpacedIn.dto.DeckRequest;
+import com.joeljebitto.SpacedIn.entity.Deck;
+import com.joeljebitto.SpacedIn.service.DeckService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/decks")
+public class DeckController {
+    private final DeckService deckService;
+
+    public DeckController(DeckService deckService) {
+        this.deckService = deckService;
+    }
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<Deck> createDeck(@PathVariable Long userId, @RequestBody DeckRequest request) {
+        return ResponseEntity.ok(deckService.createDeck(userId, request));
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<Deck>> getUserDecks(@PathVariable Long userId) {
+        return ResponseEntity.ok(deckService.getUserDecks(userId));
+    }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/AuthResponse.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/AuthResponse.java
@@ -1,0 +1,12 @@
+package com.joeljebitto.SpacedIn.dto;
+
+public class AuthResponse {
+    private String token;
+
+    public AuthResponse(String token) {
+        this.token = token;
+    }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/DeckRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/DeckRequest.java
@@ -1,0 +1,8 @@
+package com.joeljebitto.SpacedIn.dto;
+
+public class DeckRequest {
+    private String title;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/LoginRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.joeljebitto.SpacedIn.dto;
+
+public class LoginRequest {
+    private String username;
+    private String password;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/RegisterRequest.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/RegisterRequest.java
@@ -1,0 +1,14 @@
+package com.joeljebitto.SpacedIn.dto;
+
+public class RegisterRequest {
+    private String username;
+    private String password;
+    private String email;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Deck.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Deck.java
@@ -1,0 +1,20 @@
+package com.joeljebitto.SpacedIn.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Deck {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    @ManyToOne
+    private User owner;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public User getOwner() { return owner; }
+    public void setOwner(User owner) { this.owner = owner; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
@@ -1,0 +1,23 @@
+package com.joeljebitto.SpacedIn.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Flashcard {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String question;
+    private String answer;
+    @ManyToOne
+    private Deck deck;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getQuestion() { return question; }
+    public void setQuestion(String question) { this.question = question; }
+    public String getAnswer() { return answer; }
+    public void setAnswer(String answer) { this.answer = answer; }
+    public Deck getDeck() { return deck; }
+    public void setDeck(Deck deck) { this.deck = deck; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Role.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Role.java
@@ -1,0 +1,6 @@
+package com.joeljebitto.SpacedIn.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/User.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/User.java
@@ -1,0 +1,27 @@
+package com.joeljebitto.SpacedIn.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+    private String email;
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.USER;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/repository/DeckRepository.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/repository/DeckRepository.java
@@ -1,0 +1,11 @@
+package com.joeljebitto.SpacedIn.repository;
+
+import com.joeljebitto.SpacedIn.entity.Deck;
+import com.joeljebitto.SpacedIn.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DeckRepository extends JpaRepository<Deck, Long> {
+    List<Deck> findByOwner(User owner);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/repository/FlashcardRepository.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/repository/FlashcardRepository.java
@@ -1,0 +1,11 @@
+package com.joeljebitto.SpacedIn.repository;
+
+import com.joeljebitto.SpacedIn.entity.Deck;
+import com.joeljebitto.SpacedIn.entity.Flashcard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FlashcardRepository extends JpaRepository<Flashcard, Long> {
+    List<Flashcard> findByDeck(Deck deck);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/repository/UserRepository.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.joeljebitto.SpacedIn.repository;
+
+import com.joeljebitto.SpacedIn.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/security/JwtUtils.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/security/JwtUtils.java
@@ -1,0 +1,28 @@
+package com.joeljebitto.SpacedIn.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtils {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    public String generateToken(String username) {
+        Key key = Keys.hmacShaKeyFor(secret.getBytes());
+        return Jwts.builder()
+                .setSubject(username)
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/security/SecurityConfig.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/security/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.joeljebitto.SpacedIn.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/AuthService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.joeljebitto.SpacedIn.service;
+
+import com.joeljebitto.SpacedIn.dto.AuthResponse;
+import com.joeljebitto.SpacedIn.dto.LoginRequest;
+import com.joeljebitto.SpacedIn.dto.RegisterRequest;
+import com.joeljebitto.SpacedIn.entity.User;
+import com.joeljebitto.SpacedIn.repository.UserRepository;
+import com.joeljebitto.SpacedIn.security.JwtUtils;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtUtils jwtUtils;
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public AuthService(UserRepository userRepository, JwtUtils jwtUtils) {
+        this.userRepository = userRepository;
+        this.jwtUtils = jwtUtils;
+    }
+
+    public void register(RegisterRequest req) {
+        User user = new User();
+        user.setUsername(req.getUsername());
+        user.setPassword(passwordEncoder.encode(req.getPassword()));
+        user.setEmail(req.getEmail());
+        userRepository.save(user);
+    }
+
+    public AuthResponse login(LoginRequest req) {
+        User user = userRepository.findByUsername(req.getUsername()).orElseThrow();
+        if (passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            String token = jwtUtils.generateToken(user.getUsername());
+            return new AuthResponse(token);
+        }
+        throw new RuntimeException("Invalid credentials");
+    }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/DeckService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/DeckService.java
@@ -1,0 +1,34 @@
+package com.joeljebitto.SpacedIn.service;
+
+import com.joeljebitto.SpacedIn.dto.DeckRequest;
+import com.joeljebitto.SpacedIn.entity.Deck;
+import com.joeljebitto.SpacedIn.entity.User;
+import com.joeljebitto.SpacedIn.repository.DeckRepository;
+import com.joeljebitto.SpacedIn.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DeckService {
+    private final DeckRepository deckRepository;
+    private final UserRepository userRepository;
+
+    public DeckService(DeckRepository deckRepository, UserRepository userRepository) {
+        this.deckRepository = deckRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Deck createDeck(Long userId, DeckRequest request) {
+        User owner = userRepository.findById(userId).orElseThrow();
+        Deck deck = new Deck();
+        deck.setTitle(request.getTitle());
+        deck.setOwner(owner);
+        return deckRepository.save(deck);
+    }
+
+    public List<Deck> getUserDecks(Long userId) {
+        User owner = userRepository.findById(userId).orElseThrow();
+        return deckRepository.findByOwner(owner);
+    }
+}

--- a/SpacedIn/README.md
+++ b/SpacedIn/README.md
@@ -1,12 +1,17 @@
-# React + Vite
+# SpacedIn Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This React application provides the user interface for **SpacedIn**. It is built with Vite and Tailwind CSS.
 
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
-## Expanding the ESLint configuration
+## Running locally
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+pnpm install
+pnpm dev
+```
+
+The development server will be available on `http://localhost:5173` by default.

--- a/SpacedIn/src/App.jsx
+++ b/SpacedIn/src/App.jsx
@@ -1,9 +1,9 @@
 
 
+import Router from './routes.jsx'
+
 function App() {
-  return (
-    <div></div>
-  );
+  return <Router />
 }
 
 export default App;

--- a/SpacedIn/src/pages/Login.jsx
+++ b/SpacedIn/src/pages/Login.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export default function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    const data = await res.json()
+    localStorage.setItem('token', data.token)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2" />
+      <button className="bg-blue-600 text-white p-2">Login</button>
+    </form>
+  )
+}

--- a/SpacedIn/src/pages/Register.jsx
+++ b/SpacedIn/src/pages/Register.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export default function Register() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, email })
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2" />
+      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="border p-2" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2" />
+      <button className="bg-blue-600 text-white p-2">Register</button>
+    </form>
+  )
+}

--- a/SpacedIn/src/routes.jsx
+++ b/SpacedIn/src/routes.jsx
@@ -1,0 +1,14 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Login from './pages/Login.jsx'
+import Register from './pages/Register.jsx'
+
+export default function Router() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/SpacedIn/todo.txt
+++ b/SpacedIn/todo.txt
@@ -1,2 +1,2 @@
-1->login page and sign up page
+Completed: login and sign up pages
 


### PR DESCRIPTION
## Summary
- add Spring entities, repositories, services and controllers for auth and decks
- provide basic security config and JWT utility
- add simple login and register pages in React frontend
- wire up routing and update README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686156755d00832d96dd3408f7c345b2