### PR TITLE
Fix JSON recursion in deck and flashcard

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Deck.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Deck.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 @Entity
 public class Deck {
@@ -16,6 +17,7 @@ public class Deck {
   @ManyToOne
   private User owner;
 
+  @JsonManagedReference
   @OneToMany(mappedBy = "deck", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Flashcard> flashcards = new ArrayList<>();
 

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
@@ -1,6 +1,7 @@
 package com.joeljebitto.SpacedIn.entity;
 
 import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 @Entity
 public class Flashcard {
@@ -9,6 +10,7 @@ public class Flashcard {
     private Long id;
     private String question;
     private String answer;
+    @JsonBackReference
     @ManyToOne
     private Deck deck;
 


### PR DESCRIPTION
## Summary
- add Jackson annotations on entities to avoid recursive Deck <-> Flashcard references

## Testing
- `./mvnw test` *(fails: could not resolve Spring parent POM)*
- `npm test` *(no output / no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68616cad1c1c832d807db8a4cd24bdf8