### PR TITLE
Fix CardProgress column mapping

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/CardProgress.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/CardProgress.java
@@ -10,15 +10,25 @@ public class CardProgress {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne
+    @JoinColumn(name = "card_id")
     private Flashcard card;
 
+    @Column(name = "easiness_factor")
     private double easinessFactor = 2.5;
+
     private int repetitions = 0;
+
+    @Column(name = "interval_days")
     private int interval;
+
+    @Column(name = "last_review")
     private LocalDate lastReviewed;
+
+    @Column(name = "next_review")
     private LocalDate nextReviewDate;
 
     public Long getId() { return id; }

--- a/Server/src/test/java/com/joeljebitto/SpacedIn/ProgressServiceTest.java
+++ b/Server/src/test/java/com/joeljebitto/SpacedIn/ProgressServiceTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ProgressServiceTest {
     @Test
-    void updateProgressIncreasesRepetitions() {
+    void reviewCardCreatesProgressAndIncrementsRepetitions() {
         User user = new User();
         user.setId(1L);
         Flashcard card = new Flashcard();
@@ -28,10 +28,38 @@ public class ProgressServiceTest {
 
         Mockito.when(userRepo.findById(1L)).thenReturn(Optional.of(user));
         Mockito.when(cardRepo.findById(2L)).thenReturn(Optional.of(card));
+        Mockito.when(progressRepo.findByUserAndCard(user, card)).thenReturn(null);
         Mockito.when(progressRepo.save(Mockito.any())).thenAnswer(i -> i.getArgument(0));
 
         ProgressService service = new ProgressService(progressRepo, userRepo, cardRepo);
-        CardProgress p = service.updateProgress(1L,2L,5);
+        CardProgress p = service.reviewCard(1L,2L,5);
         assertEquals(1, p.getRepetitions());
+    }
+
+    @Test
+    void reviewCardResetsProgressOnLowQuality() {
+        User user = new User();
+        user.setId(1L);
+        Flashcard card = new Flashcard();
+        card.setId(2L);
+        CardProgress progress = new CardProgress();
+        progress.setUser(user);
+        progress.setCard(card);
+        progress.setRepetitions(3);
+        progress.setInterval(10);
+
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+        FlashcardRepository cardRepo = Mockito.mock(FlashcardRepository.class);
+        CardProgressRepository progressRepo = Mockito.mock(CardProgressRepository.class);
+
+        Mockito.when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+        Mockito.when(cardRepo.findById(2L)).thenReturn(Optional.of(card));
+        Mockito.when(progressRepo.findByUserAndCard(user, card)).thenReturn(progress);
+        Mockito.when(progressRepo.save(Mockito.any())).thenAnswer(i -> i.getArgument(0));
+
+        ProgressService service = new ProgressService(progressRepo, userRepo, cardRepo);
+        CardProgress result = service.reviewCard(1L,2L,1);
+        assertEquals(0, result.getRepetitions());
+        assertEquals(1, result.getInterval());
     }
 }


### PR DESCRIPTION
## Summary
- map JPA fields to existing database column names

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68628f6cf6e4832dbac67fc30bf58cb3