### PR TITLE
Fix deck/card delete constraint

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
@@ -1,6 +1,12 @@
 package com.joeljebitto.SpacedIn.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.joeljebitto.SpacedIn.entity.CardProgress;
 
 import jakarta.persistence.*;
 
@@ -15,6 +21,10 @@ public class Flashcard {
   @ManyToOne
   @JoinColumn(name = "deck_id")
   private Deck deck;
+
+  @JsonIgnore
+  @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<CardProgress> progressRecords = new ArrayList<>();
 
   public Long getId() {
     return id;
@@ -46,5 +56,13 @@ public class Flashcard {
 
   public void setDeck(Deck deck) {
     this.deck = deck;
+  }
+
+  public List<CardProgress> getProgressRecords() {
+    return progressRecords;
+  }
+
+  public void setProgressRecords(List<CardProgress> progressRecords) {
+    this.progressRecords = progressRecords;
   }
 }


### PR DESCRIPTION
## Summary
- cascade delete card progress when deleting flashcards

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862a30979ac832dad2ec95c9d9aaf07