### PR TITLE
Refresh progress bars with deck/card changes

### DIFF
--- a/SpacedIn/src/components/CardList.jsx
+++ b/SpacedIn/src/components/CardList.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { api } from '../services/api'
 import RichTextEditor from './RichTextEditor'
 
-export default function CardList({ deckId }) {
+export default function CardList({ deckId, onChange }) {
   const [cards, setCards] = useState([])
   const [question, setQuestion] = useState('')
   const [answer, setAnswer] = useState('')
@@ -16,14 +16,17 @@ export default function CardList({ deckId }) {
 
   const create = async (e) => {
     e.preventDefault()
+    if (!question.trim() || !answer.trim()) return
     const card = await api.createCard({ deckId, question, answer })
     setCards([...cards, card])
     setQuestion(''); setAnswer('')
+    onChange && onChange()
   }
 
   const remove = async (id) => {
     await api.deleteCard(id)
     setCards(cards.filter(c => c.id !== id))
+    onChange && onChange()
   }
 
   const startEdit = (c) => {
@@ -39,6 +42,7 @@ export default function CardList({ deckId }) {
     })
     setCards(cards.map(c => (c.id === id ? updated : c)))
     setEditingId(null)
+    onChange && onChange()
   }
 
   return (
@@ -46,7 +50,12 @@ export default function CardList({ deckId }) {
       <form onSubmit={create} className="space-y-2">
         <RichTextEditor value={question} onChange={setQuestion} placeholder="Question" />
         <RichTextEditor value={answer} onChange={setAnswer} placeholder="Answer" />
-        <button className="bg-green-600 text-white px-3 mt-2">Add</button>
+        <button
+          className="bg-green-600 text-white px-3 mt-2 disabled:opacity-50"
+          disabled={!question.trim() || !answer.trim()}
+        >
+          Add
+        </button>
       </form>
       <ul className="space-y-2">
         {cards.map(c => (

--- a/SpacedIn/src/components/DeckList.jsx
+++ b/SpacedIn/src/components/DeckList.jsx
@@ -3,7 +3,7 @@ import useAuth from "../store/useAuth";
 import { api } from "../services/api";
 import { Link } from "react-router-dom";
 
-export default function DeckList({ userId }) {
+export default function DeckList({ userId, onChange }) {
   const { user } = useAuth();
   const [decks, setDecks] = useState([]);
   const [stats, setStats] = useState({});
@@ -30,15 +30,18 @@ export default function DeckList({ userId }) {
 
   const create = async (e) => {
     e.preventDefault();
+    if (!title.trim()) return;
     console.log(user.id);
     const deck = await api.createDeck(user.id, { title });
     setDecks([...decks, deck]);
     setTitle("");
+    onChange && onChange();
   };
 
   const remove = async (id) => {
     await api.deleteDeck(id);
     setDecks(decks.filter((d) => d.id !== id));
+    onChange && onChange();
   };
 
   const startEdit = (deck) => {
@@ -61,7 +64,12 @@ export default function DeckList({ userId }) {
           placeholder="New Deck"
           className="border p-2"
         />
-        <button className="bg-green-600 text-white px-3">Add</button>
+        <button
+          className="bg-green-600 text-white px-3 disabled:opacity-50"
+          disabled={!title.trim()}
+        >
+          Add
+        </button>
       </form>
       <ul className="space-y-2">
         {decks.map((d) => (

--- a/SpacedIn/src/pages/Dashboard.jsx
+++ b/SpacedIn/src/pages/Dashboard.jsx
@@ -1,18 +1,22 @@
 import DeckList from "../components/DeckList.jsx";
 import useAuth from "../store/useAuth";
 import { Navigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { api } from "../services/api";
 
 export default function Dashboard() {
   const { token, user } = useAuth();
   const [stats, setStats] = useState(null);
 
-  useEffect(() => {
+  const refreshStats = useCallback(() => {
     if (user?.id) {
       api.getUserStats(user.id).then(setStats).catch(console.error);
     }
   }, [user]);
+
+  useEffect(() => {
+    refreshStats();
+  }, [refreshStats]);
 
   if (!token) return <Navigate to="/" replace />;
   return (
@@ -33,7 +37,7 @@ export default function Dashboard() {
           </div>
         </div>
       )}
-      <DeckList userId={user?.id} />
+      <DeckList userId={user?.id} onChange={refreshStats} />
     </div>
   );
 }

--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import CardList from "../components/CardList.jsx";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import useAuth from "../store/useAuth";
 import { api } from "../services/api";
 
@@ -9,11 +9,15 @@ export default function Deck() {
   const { user } = useAuth();
   const [stats, setStats] = useState(null);
 
-  useEffect(() => {
+  const refreshStats = useCallback(() => {
     if (user?.id) {
       api.getDeckStats(id, user.id).then(setStats).catch(console.error);
     }
   }, [id, user]);
+
+  useEffect(() => {
+    refreshStats();
+  }, [refreshStats]);
 
   return (
     <div className="p-4 space-y-4 w-full">
@@ -39,7 +43,7 @@ export default function Deck() {
       <Link to={`/decks/${id}/review`} className="text-green-600 block">
         Study
       </Link>
-      <CardList deckId={id} />
+      <CardList deckId={id} onChange={refreshStats} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh dashboard progress when decks change
- refresh deck progress when cards change
- wire refresh callbacks through components
- prevent creation of empty decks or cards

## Testing
- `./mvnw -q test` *(fails: unable to resolve Spring dependencies)*
- `pnpm lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6862a4f5c71c832dba17b384e3bc43c1