### PR TITLE
Refresh stats on deck edits

### DIFF
--- a/SpacedIn/index.html
+++ b/SpacedIn/index.html
@@ -7,7 +7,7 @@
     <title>Vite + React</title>
   </head>
   <body
-    class="bg-gradient-to-b from-[#f8fafc] via-[#e0f2fe] to-[#bae6fd] h-full font-mono"
+    class="bg-gradient-to-b from-white via-gray-100 to-gray-200 h-full font-sans"
   >
     <div id="root" class="h-screen overflow-auto"></div>
     <script type="module" src="/src/main.jsx"></script>

--- a/SpacedIn/src/components/CardList.jsx
+++ b/SpacedIn/src/components/CardList.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { api } from '../services/api'
 import RichTextEditor from './RichTextEditor'
 
-export default function CardList({ deckId }) {
+export default function CardList({ deckId, onChange }) {
   const [cards, setCards] = useState([])
   const [question, setQuestion] = useState('')
   const [answer, setAnswer] = useState('')
@@ -16,14 +16,17 @@ export default function CardList({ deckId }) {
 
   const create = async (e) => {
     e.preventDefault()
+    if (!question.trim() || !answer.trim()) return
     const card = await api.createCard({ deckId, question, answer })
     setCards([...cards, card])
     setQuestion(''); setAnswer('')
+    onChange && onChange()
   }
 
   const remove = async (id) => {
     await api.deleteCard(id)
     setCards(cards.filter(c => c.id !== id))
+    onChange && onChange()
   }
 
   const startEdit = (c) => {
@@ -33,12 +36,14 @@ export default function CardList({ deckId }) {
   }
 
   const save = async (id) => {
+    if (!editQuestion.trim() || !editAnswer.trim()) return
     const updated = await api.updateCard(id, {
       question: editQuestion,
       answer: editAnswer,
     })
     setCards(cards.map(c => (c.id === id ? updated : c)))
     setEditingId(null)
+    onChange && onChange()
   }
 
   return (
@@ -46,18 +51,34 @@ export default function CardList({ deckId }) {
       <form onSubmit={create} className="space-y-2">
         <RichTextEditor value={question} onChange={setQuestion} placeholder="Question" />
         <RichTextEditor value={answer} onChange={setAnswer} placeholder="Answer" />
-        <button className="bg-green-600 text-white px-3 mt-2">Add</button>
+        <button
+          className="bg-green-600 text-white rounded px-3 mt-2 disabled:opacity-50"
+          disabled={!question.trim() || !answer.trim()}
+        >
+          Add
+        </button>
       </form>
       <ul className="space-y-2">
         {cards.map(c => (
-          <li key={c.id} className="border p-2">
+          <li key={c.id} className="border rounded p-4 bg-white shadow">
             {editingId === c.id ? (
               <div className="space-y-2">
                 <RichTextEditor value={editQuestion} onChange={setEditQuestion} />
                 <RichTextEditor value={editAnswer} onChange={setEditAnswer} />
                 <div className="flex gap-2">
-                  <button onClick={() => save(c.id)} className="text-green-600">Save</button>
-                  <button onClick={() => setEditingId(null)} className="text-gray-600">Cancel</button>
+                  <button
+                    onClick={() => save(c.id)}
+                    className="text-green-600 disabled:opacity-50"
+                    disabled={!editQuestion.trim() || !editAnswer.trim()}
+                  >
+                    Save
+                  </button>
+                  <button
+                    onClick={() => setEditingId(null)}
+                    className="text-gray-600"
+                  >
+                    Cancel
+                  </button>
                 </div>
               </div>
             ) : (
@@ -67,8 +88,15 @@ export default function CardList({ deckId }) {
                   <span className="text-sm text-gray-600 block" dangerouslySetInnerHTML={{ __html: c.answer }} />
                 </div>
                 <div className="flex gap-2">
-                  <button onClick={() => startEdit(c)} className="text-blue-600">Edit</button>
-                  <button onClick={() => remove(c.id)} className="text-red-600">X</button>
+                  <button
+                    onClick={() => startEdit(c)}
+                    className="text-blue-600"
+                  >
+                    Edit
+                  </button>
+                  <button onClick={() => remove(c.id)} className="text-red-600">
+                    X
+                  </button>
                 </div>
               </div>
             )}

--- a/SpacedIn/src/components/DeckList.jsx
+++ b/SpacedIn/src/components/DeckList.jsx
@@ -3,7 +3,7 @@ import useAuth from "../store/useAuth";
 import { api } from "../services/api";
 import { Link } from "react-router-dom";
 
-export default function DeckList({ userId }) {
+export default function DeckList({ userId, onChange }) {
   const { user } = useAuth();
   const [decks, setDecks] = useState([]);
   const [stats, setStats] = useState({});
@@ -30,15 +30,17 @@ export default function DeckList({ userId }) {
 
   const create = async (e) => {
     e.preventDefault();
-    console.log(user.id);
+    if (!title.trim()) return;
     const deck = await api.createDeck(user.id, { title });
     setDecks([...decks, deck]);
     setTitle("");
+    onChange && onChange();
   };
 
   const remove = async (id) => {
     await api.deleteDeck(id);
     setDecks(decks.filter((d) => d.id !== id));
+    onChange && onChange();
   };
 
   const startEdit = (deck) => {
@@ -47,9 +49,11 @@ export default function DeckList({ userId }) {
   };
 
   const save = async (id) => {
+    if (!editTitle.trim()) return;
     const updated = await api.updateDeck(id, { title: editTitle });
     setDecks(decks.map((d) => (d.id === id ? updated : d)));
     setEditingId(null);
+    onChange && onChange();
   };
 
   return (
@@ -59,21 +63,30 @@ export default function DeckList({ userId }) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="New Deck"
-          className="border p-2"
+          className="border rounded p-2 flex-1"
         />
-        <button className="bg-green-600 text-white px-3">Add</button>
+        <button
+          className="bg-green-600 text-white rounded px-3 disabled:opacity-50"
+          disabled={!title.trim()}
+        >
+          Add
+        </button>
       </form>
       <ul className="space-y-2">
         {decks.map((d) => (
-          <li key={d.id} className="border p-2 space-y-1">
+          <li key={d.id} className="border rounded p-4 space-y-1 bg-white shadow">
             {editingId === d.id ? (
               <div className="flex justify-between items-center gap-2">
                 <input
                   value={editTitle}
                   onChange={(e) => setEditTitle(e.target.value)}
-                  className="border p-2 flex-1"
+                  className="border rounded p-2 flex-1"
                 />
-                <button onClick={() => save(d.id)} className="text-green-600">
+                <button
+                  onClick={() => save(d.id)}
+                  className="text-green-600 disabled:opacity-50"
+                  disabled={!editTitle.trim()}
+                >
                   Save
                 </button>
                 <button

--- a/SpacedIn/src/components/Header.jsx
+++ b/SpacedIn/src/components/Header.jsx
@@ -1,15 +1,13 @@
 import { useNavigate } from "react-router-dom";
 import useAuth from "../store/useAuth";
-const Btn = ({ children, onClick }) => {
-  return (
-    <button
-      className="p-3 transition-all hover:cursor-pointer active:bg-gray-800 rounded-xl"
-      onClick={onClick}
-    >
-      {children}
-    </button>
-  );
-};
+const Btn = ({ children, onClick }) => (
+  <button
+    className="px-3 py-2 rounded-md hover:bg-gray-100 active:bg-gray-200 text-sm font-medium"
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
 
 const Header = () => {
   const { logout, token } = useAuth();
@@ -26,14 +24,14 @@ const Header = () => {
   };
 
   return (
-    <div className="bg-black/99 z-100 flex w-full px-5 py-3 text-white shadow-2xl lg:w-[60rem] lg:rounded-2xl mx-auto lg:mt-3 ">
+    <div className="bg-white shadow-sm flex w-full justify-between px-5 py-3 sticky top-0 z-50">
       <h1
         className="flex-1 text-xl font-bold my-auto"
         onClick={() => navigate("/dashboard")}
       >
         SpacedIn
       </h1>
-      <div className="flex">
+      <div className="flex gap-2">
         {token ? (
           <Btn onClick={handleLogout}>Logout</Btn>
         ) : (

--- a/SpacedIn/src/components/Layout.jsx
+++ b/SpacedIn/src/components/Layout.jsx
@@ -4,10 +4,8 @@ import { Outlet } from "react-router-dom";
 export default function Layout() {
   return (
     <>
-      <div className="bg-white/90 absolute z-50 flex w-full left-1/2 transform -translate-x-1/2 ">
-        <Header />
-      </div>
-      <main className="flex mt-25 w-screen lg:w-[55rem] mx-auto bg-black/90 text-white">
+      <Header />
+      <main className="flex flex-col pt-16 w-screen max-w-4xl mx-auto p-4">
         <Outlet />
       </main>
     </>

--- a/SpacedIn/src/pages/Dashboard.jsx
+++ b/SpacedIn/src/pages/Dashboard.jsx
@@ -1,18 +1,22 @@
 import DeckList from "../components/DeckList.jsx";
 import useAuth from "../store/useAuth";
 import { Navigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { api } from "../services/api";
 
 export default function Dashboard() {
   const { token, user } = useAuth();
   const [stats, setStats] = useState(null);
 
-  useEffect(() => {
+  const refreshStats = useCallback(() => {
     if (user?.id) {
       api.getUserStats(user.id).then(setStats).catch(console.error);
     }
   }, [user]);
+
+  useEffect(() => {
+    refreshStats();
+  }, [refreshStats]);
 
   if (!token) return <Navigate to="/" replace />;
   return (
@@ -27,13 +31,13 @@ export default function Dashboard() {
               }}
             />
           </div>
-          <div className="text-sm text-gray-200">
-            Reviewed {stats.reviewedCards} / {stats.totalCards} cards (Due{" "}
+          <div className="text-sm text-gray-700">
+            Reviewed {stats.reviewedCards} / {stats.totalCards} cards (Due{' '}
             {stats.dueCards})
           </div>
         </div>
       )}
-      <DeckList userId={user?.id} />
+      <DeckList userId={user?.id} onChange={refreshStats} />
     </div>
   );
 }

--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import CardList from "../components/CardList.jsx";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import useAuth from "../store/useAuth";
 import { api } from "../services/api";
 
@@ -9,11 +9,15 @@ export default function Deck() {
   const { user } = useAuth();
   const [stats, setStats] = useState(null);
 
-  useEffect(() => {
+  const refreshStats = useCallback(() => {
     if (user?.id) {
       api.getDeckStats(id, user.id).then(setStats).catch(console.error);
     }
   }, [id, user]);
+
+  useEffect(() => {
+    refreshStats();
+  }, [refreshStats]);
 
   return (
     <div className="p-4 space-y-4 w-full">
@@ -36,10 +40,13 @@ export default function Deck() {
           </div>
         </div>
       )}
-      <Link to={`/decks/${id}/review`} className="text-green-600 block">
+      <Link
+        to={`/decks/${id}/review`}
+        className="bg-blue-600 text-white rounded px-3 py-2 inline-block"
+      >
         Study
       </Link>
-      <CardList deckId={id} />
+      <CardList deckId={id} onChange={refreshStats} />
     </div>
   );
 }

--- a/SpacedIn/src/pages/Login.jsx
+++ b/SpacedIn/src/pages/Login.jsx
@@ -17,10 +17,24 @@ export default function Login() {
   if (token) return <Navigate to="/dashboard" replace />
 
   return (
-    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2 max-w-sm mx-auto">
-      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2" />
-      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2" />
-      <button className="bg-blue-600 text-white p-2">Login</button>
+    <form
+      onSubmit={handleSubmit}
+      className="p-6 bg-white shadow rounded flex flex-col gap-4 max-w-sm mx-auto"
+    >
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Username"
+        className="border rounded p-2"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="border rounded p-2"
+      />
+      <button className="bg-blue-600 text-white rounded p-2">Login</button>
     </form>
   )
 }

--- a/SpacedIn/src/pages/Register.jsx
+++ b/SpacedIn/src/pages/Register.jsx
@@ -20,12 +20,31 @@ export default function Register() {
   if (done) return <Navigate to="/" replace />
 
   return (
-    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2 max-w-sm mx-auto">
-      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2" />
-      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="border p-2" />
-      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2" />
-      <button className="bg-blue-600 text-white p-2">Register</button>
-      <Link to="/" className="text-blue-600">Login</Link>
+    <form
+      onSubmit={handleSubmit}
+      className="p-6 bg-white shadow rounded flex flex-col gap-4 max-w-sm mx-auto"
+    >
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Username"
+        className="border rounded p-2"
+      />
+      <input
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border rounded p-2"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="border rounded p-2"
+      />
+      <button className="bg-blue-600 text-white rounded p-2">Register</button>
+      <Link to="/" className="text-blue-600 text-center">Login</Link>
     </form>
   )
 }

--- a/SpacedIn/src/pages/Review.jsx
+++ b/SpacedIn/src/pages/Review.jsx
@@ -61,7 +61,7 @@ export default function Review() {
           Reviewed {reviewed} / {totalCards} cards
         </div>
       </div>
-      <div className="border p-4">
+      <div className="border rounded p-4 bg-white shadow">
         <div dangerouslySetInnerHTML={{ __html: card.question }} />
         {showAnswer && (
           <div
@@ -73,7 +73,7 @@ export default function Review() {
       {showAnswer ? (
         <div className="flex gap-2">
           {[0, 1, 2, 3, 4, 5].map((n) => (
-            <button key={n} onClick={() => grade(n)} className="border px-2">
+            <button key={n} onClick={() => grade(n)} className="border rounded px-2">
               {n}
             </button>
           ))}
@@ -81,7 +81,7 @@ export default function Review() {
       ) : (
         <button
           onClick={() => setShowAnswer(true)}
-          className="bg-blue-600 text-white px-3"
+          className="bg-blue-600 text-white rounded px-3 py-2"
         >
           Show Answer
         </button>


### PR DESCRIPTION
## Summary
- call progress refresh after editing decks
- remove stray `console.log`
- ensure card edits trigger refresh via `onChange`
- modernize styling across pages

## Testing
- `./Server/mvnw -q test` *(fails: no POM in directory)*
- `pnpm lint` *(fails: Cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6862a4f5c71c832dba17b384e3bc43c1