### PR TITLE
AI answer generation feature

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AiController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AiController.java
@@ -3,6 +3,7 @@ package com.joeljebitto.SpacedIn.controller;
 import com.joeljebitto.SpacedIn.service.AiService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/ai")
@@ -27,5 +28,15 @@ public class AiController {
     @PostMapping("/generate-cards")
     public ResponseEntity<String> generate(@RequestBody String topic) {
         return ResponseEntity.ok(aiService.generateCards(topic));
+    }
+
+    @PostMapping("/answer")
+    public ResponseEntity<String> answer(@RequestBody String question) {
+        return ResponseEntity.ok(aiService.generateAnswer(question));
+    }
+
+    @GetMapping(value = "/answer-stream", produces = "text/event-stream")
+    public SseEmitter answerStream(@RequestParam String question) {
+        return aiService.streamAnswer(question);
     }
 }

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/AiService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/AiService.java
@@ -1,18 +1,118 @@
 package com.joeljebitto.SpacedIn.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Service
 public class AiService {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
     public String explain(String question) {
-        // Placeholder for OpenAI API integration
         return "AI explanation for: " + question;
     }
+
     public String helpCard(Long cardId) {
         return "AI help for card " + cardId;
     }
 
     public String generateCards(String topic) {
         return "Generated cards for " + topic;
+    }
+
+    public String generateAnswer(String question) {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey != null && !apiKey.isBlank()) {
+            try {
+                Map<String, Object> msg = new HashMap<>();
+                msg.put("role", "user");
+                msg.put("content", question);
+                Map<String, Object> body = new HashMap<>();
+                body.put("model", "gpt-3.5-turbo");
+                body.put("messages", java.util.List.of(msg));
+                String json = mapper.writeValueAsString(body);
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("https://api.openai.com/v1/chat/completions"))
+                        .header("Authorization", "Bearer " + apiKey)
+                        .header("Content-Type", "application/json")
+                        .timeout(Duration.ofSeconds(30))
+                        .POST(HttpRequest.BodyPublishers.ofString(json))
+                        .build();
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                JsonNode node = mapper.readTree(response.body());
+                return node.get("choices").get(0).get("message").get("content").asText().trim();
+            } catch (Exception e) {
+                // fall back to local model on error
+            }
+        }
+        return callLocalModel(question, false);
+    }
+
+    public SseEmitter streamAnswer(String question) {
+        SseEmitter emitter = new SseEmitter();
+        executor.submit(() -> {
+            try {
+                callLocalModelStream(question, emitter);
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
+        return emitter;
+    }
+
+    private String callLocalModel(String question, boolean stream) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "deepseek-r1:8b");
+        body.put("prompt", question);
+        body.put("stream", stream);
+        String json = mapper.writeValueAsString(body);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:11434/api/generate"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode node = mapper.readTree(response.body());
+        return node.path("response").asText().trim();
+    }
+
+    private void callLocalModelStream(String question, SseEmitter emitter) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "deepseek-r1:8b");
+        body.put("prompt", question);
+        body.put("stream", true);
+        String json = mapper.writeValueAsString(body);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:11434/api/generate"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        HttpResponse<java.io.InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) continue;
+                JsonNode node = mapper.readTree(line);
+                String token = node.path("response").asText();
+                emitter.send(token);
+            }
+        }
+        emitter.complete();
     }
 }

--- a/SpacedIn/src/components/CardList.jsx
+++ b/SpacedIn/src/components/CardList.jsx
@@ -9,6 +9,7 @@ export default function CardList({ deckId, onChange }) {
   const [editingId, setEditingId] = useState(null)
   const [editQuestion, setEditQuestion] = useState('')
   const [editAnswer, setEditAnswer] = useState('')
+  const [streamClose, setStreamClose] = useState(null)
 
   useEffect(() => {
     api.getCards(deckId).then(setCards).catch(console.error)
@@ -51,6 +52,23 @@ export default function CardList({ deckId, onChange }) {
       <form onSubmit={create} className="space-y-2">
         <RichTextEditor value={question} onChange={setQuestion} placeholder="Question" />
         <RichTextEditor value={answer} onChange={setAnswer} placeholder="Answer" />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (streamClose) streamClose()
+              setAnswer('')
+              const close = api.streamAnswer(question, chunk => {
+                setAnswer(prev => prev + chunk)
+              })
+              setStreamClose(() => close)
+            }}
+            className="text-sm text-blue-400"
+            disabled={!question.trim()}
+          >
+            AI Generate
+          </button>
+        </div>
         <button
           className="bg-green-600 text-white rounded px-3 mt-2 disabled:opacity-50"
           disabled={!question.trim() || !answer.trim()}

--- a/SpacedIn/src/services/api.js
+++ b/SpacedIn/src/services/api.js
@@ -55,4 +55,13 @@ export const api = {
   getUserStats: (userId) => request(`/api/stats/user/${userId}`),
   getDeckStats: (deckId, userId) =>
     request(`/api/stats/deck/${deckId}?userId=${userId}`),
+  generateAnswer: (question) =>
+    request(`/api/ai/answer`, { method: "POST", body: JSON.stringify(question) }),
+  streamAnswer: (question, onMessage) => {
+    const es = new EventSource(
+      `${BASE}/api/ai/answer-stream?question=${encodeURIComponent(question)}`,
+    );
+    es.onmessage = (e) => onMessage(e.data);
+    return () => es.close();
+  },
 };


### PR DESCRIPTION
## Summary
- add ChatGPT/local LLM support to backend service
- expose new `/api/ai/answer` and streaming `/api/ai/answer-stream` endpoints
- integrate answer generation button in card list
- extend API client with generation helpers

## Testing
- `npm run lint --silent`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e538c228832da93553513e7db462