### PR TITLE
Add concise AI streaming box

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ pnpm dev
 
 The frontend dev server runs at `http://localhost:5173`.
 The frontend now includes a dashboard for managing decks and pages to view and add flashcards. Decks and cards can also be removed.
-=======

--- a/SpacedIn/src/components/LiveThinkingBox.jsx
+++ b/SpacedIn/src/components/LiveThinkingBox.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react'
+
+export default function LiveThinkingBox({ text }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.scrollTop = ref.current.scrollHeight
+    }
+  }, [text])
+
+  return (
+    <div
+      ref={ref}
+      className="border border-gray-600 bg-gray-800 text-gray-100 p-2 max-h-40 overflow-y-auto whitespace-pre-wrap"
+    >
+      {text}
+    </div>
+  )
+}

--- a/SpacedIn/src/services/api.js
+++ b/SpacedIn/src/services/api.js
@@ -57,11 +57,15 @@ export const api = {
     request(`/api/stats/deck/${deckId}?userId=${userId}`),
   generateAnswer: (question) =>
     request(`/api/ai/answer`, { method: "POST", body: JSON.stringify(question) }),
-  streamAnswer: (question, onMessage) => {
+  streamAnswer: (question, onMessage, onDone) => {
     const es = new EventSource(
       `${BASE}/api/ai/answer-stream?question=${encodeURIComponent(question)}`,
     );
     es.onmessage = (e) => onMessage(e.data);
+    es.onerror = () => {
+      es.close();
+      onDone && onDone();
+    };
     return () => es.close();
   },
 };


### PR DESCRIPTION
## Summary
- fix extraneous line in README
- create `LiveThinkingBox` component for streaming text
- auto-scroll AI streaming output in card list
- ensure AI model responses are concise
- allow `streamAnswer` to signal completion

## Testing
- `pnpm lint`
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea16e94c832d9f62a348423722f4