### PR TITLE
Fix StatsService LOB access

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/FlashcardService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/FlashcardService.java
@@ -7,6 +7,7 @@ import com.joeljebitto.SpacedIn.entity.Flashcard;
 import com.joeljebitto.SpacedIn.repository.DeckRepository;
 import com.joeljebitto.SpacedIn.repository.FlashcardRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,6 +46,7 @@ public class FlashcardService {
     flashcardRepository.deleteById(id);
   }
 
+  @Transactional(readOnly = true)
   public List<FlashcardDTO> getDeckCards(Long deckId) {
     return flashcardRepository.findByDeckId(deckId)
         .stream()

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/StatsService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/StatsService.java
@@ -9,6 +9,7 @@ import com.joeljebitto.SpacedIn.repository.DeckRepository;
 import com.joeljebitto.SpacedIn.repository.FlashcardRepository;
 import com.joeljebitto.SpacedIn.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class StatsService {
         this.progressService = progressService;
     }
 
+    @Transactional(readOnly = true)
     public StatsDTO getUserStats(Long userId) {
         User user = userRepository.findById(userId).orElseThrow();
         List<Deck> decks = deckRepository.findByOwnerId(userId);
@@ -45,6 +47,7 @@ public class StatsService {
         return new StatsDTO(totalCards, reviewed, due);
     }
 
+    @Transactional(readOnly = true)
     public StatsDTO getDeckStats(Long deckId, Long userId) {
         User user = userRepository.findById(userId).orElseThrow();
         List<Flashcard> cards = flashcardRepository.findByDeckId(deckId);


### PR DESCRIPTION
## Summary
- keep Hibernate session open when reading LOBs
- annotate StatsService and FlashcardService methods with `@Transactional(readOnly = true)`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `pnpm -s test`

------
https://chatgpt.com/codex/tasks/task_e_6863fd6f9afc832db90f9c7db4bc1f30