### PR TITLE
Add separate ChatGPT and DeepSeek buttons

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AiController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AiController.java
@@ -31,12 +31,14 @@ public class AiController {
     }
 
     @PostMapping("/answer")
-    public ResponseEntity<String> answer(@RequestBody String question) {
-        return ResponseEntity.ok(aiService.generateAnswer(question));
+    public ResponseEntity<String> answer(@RequestParam(required = false) String engine,
+                                         @RequestBody String question) {
+        return ResponseEntity.ok(aiService.generateAnswer(question, engine));
     }
 
     @GetMapping(value = "/answer-stream", produces = "text/event-stream")
-    public SseEmitter answerStream(@RequestParam String question) {
-        return aiService.streamAnswer(question);
+    public SseEmitter answerStream(@RequestParam String question,
+                                   @RequestParam(required = false) String engine) {
+        return aiService.streamAnswer(question, engine);
     }
 }

--- a/SpacedIn/src/components/CardList.jsx
+++ b/SpacedIn/src/components/CardList.jsx
@@ -58,7 +58,7 @@ export default function CardList({ deckId, onChange }) {
     onChange && onChange();
   };
 
-  const startStream = () => {
+  const startStream = (engine) => {
     if (streamClose) streamClose(); // Close any existing stream
 
     setIsStreaming(true);
@@ -77,6 +77,7 @@ export default function CardList({ deckId, onChange }) {
         setIsStreaming(false);
         setAnswer(answer.trim());
       },
+      engine,
     );
 
     // ✅ Properly store the stream closer
@@ -99,11 +100,19 @@ export default function CardList({ deckId, onChange }) {
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={startStream}
+            onClick={() => startStream("chatgpt")}
             className="text-sm text-blue-400"
             disabled={!question.trim() || isStreaming}
           >
-            AI Generate
+            ChatGPT
+          </button>
+          <button
+            type="button"
+            onClick={() => startStream("deepseek")}
+            className="text-sm text-purple-400"
+            disabled={!question.trim() || isStreaming}
+          >
+            DeepSeek
           </button>
         </div>
         {isStreaming && <LiveThinkingBox text={reasoningText} />}

--- a/SpacedIn/src/services/api.js
+++ b/SpacedIn/src/services/api.js
@@ -55,11 +55,16 @@ export const api = {
   getUserStats: (userId) => request(`/api/stats/user/${userId}`),
   getDeckStats: (deckId, userId) =>
     request(`/api/stats/deck/${deckId}?userId=${userId}`),
-  generateAnswer: (question) =>
-    request(`/api/ai/answer`, { method: "POST", body: JSON.stringify(question) }),
-  streamAnswer: (question, onMessage, onDone) => {
+  generateAnswer: (question, engine = "auto") =>
+    request(`/api/ai/answer?engine=${engine}`, {
+      method: "POST",
+      body: JSON.stringify(question),
+    }),
+  streamAnswer: (question, onMessage, onDone, engine = "auto") => {
     const es = new EventSource(
-      `${BASE}/api/ai/answer-stream?question=${encodeURIComponent(question)}`,
+      `${BASE}/api/ai/answer-stream?question=${encodeURIComponent(
+        question,
+      )}&engine=${engine}`,
     );
     es.onmessage = (e) => onMessage(e.data);
     es.onerror = () => {


### PR DESCRIPTION
## Summary
- add `engine` query parameter so API can choose ChatGPT or DeepSeek
- support engine selection in `AiService`
- expose the option in the frontend API client
- display two buttons in `CardList` to pick ChatGPT or DeepSeek

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865361661e8832da5254a92529e5a66