### PR TITLE
Refactor controllers to avoid entities

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AdminController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/AdminController.java
@@ -1,6 +1,6 @@
 package com.joeljebitto.SpacedIn.controller;
 
-import com.joeljebitto.SpacedIn.entity.User;
+import com.joeljebitto.SpacedIn.dto.UserDTO;
 import com.joeljebitto.SpacedIn.repository.UserRepository;
 import com.joeljebitto.SpacedIn.service.AdminService;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +20,11 @@ public class AdminController {
     }
 
     @GetMapping("/users")
-    public ResponseEntity<List<User>> getUsers() {
-        return ResponseEntity.ok(userRepository.findAll());
+    public ResponseEntity<List<UserDTO>> getUsers() {
+        List<UserDTO> users = userRepository.findAll().stream()
+                .map(UserDTO::new)
+                .toList();
+        return ResponseEntity.ok(users);
     }
 
     @DeleteMapping("/deck/{id}")

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/DeckController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/DeckController.java
@@ -3,7 +3,6 @@ package com.joeljebitto.SpacedIn.controller;
 import com.joeljebitto.SpacedIn.dto.DeckDTO;
 import com.joeljebitto.SpacedIn.dto.DeckRequest;
 import com.joeljebitto.SpacedIn.dto.FlashcardDTO;
-import com.joeljebitto.SpacedIn.entity.Deck;
 import com.joeljebitto.SpacedIn.service.DeckService;
 import com.joeljebitto.SpacedIn.service.ProgressService;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +23,8 @@ public class DeckController {
   }
 
   @PostMapping("/{userId}")
-  public ResponseEntity<Deck> createDeck(@PathVariable Long userId, @RequestBody DeckRequest request) {
-    return ResponseEntity.ok(deckService.createDeck(userId, request));
+  public ResponseEntity<DeckDTO> createDeck(@PathVariable Long userId, @RequestBody DeckRequest request) {
+    return ResponseEntity.ok(new DeckDTO(deckService.createDeck(userId, request)));
   }
 
   @GetMapping("/user/{userId}")
@@ -34,8 +33,8 @@ public class DeckController {
   }
 
   @PutMapping("/{id}")
-  public ResponseEntity<Deck> updateDeck(@PathVariable Long id, @RequestBody DeckRequest request) {
-    return ResponseEntity.ok(deckService.updateDeck(id, request));
+  public ResponseEntity<DeckDTO> updateDeck(@PathVariable Long id, @RequestBody DeckRequest request) {
+    return ResponseEntity.ok(new DeckDTO(deckService.updateDeck(id, request)));
   }
 
   @DeleteMapping("/{id}")
@@ -53,7 +52,7 @@ public class DeckController {
   }
 
   @GetMapping("/share/{id}")
-  public ResponseEntity<Deck> shareDeck(@PathVariable Long id) {
-    return ResponseEntity.ok(deckService.getDeck(id));
+  public ResponseEntity<DeckDTO> shareDeck(@PathVariable Long id) {
+    return ResponseEntity.ok(new DeckDTO(deckService.getDeck(id)));
   }
 }

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/ProgressController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/ProgressController.java
@@ -1,6 +1,6 @@
 package com.joeljebitto.SpacedIn.controller;
 
-import com.joeljebitto.SpacedIn.entity.CardProgress;
+import com.joeljebitto.SpacedIn.dto.CardProgressDTO;
 import com.joeljebitto.SpacedIn.service.ProgressService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,12 +17,16 @@ public class ProgressController {
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<List<CardProgress>> getProgress(@PathVariable Long userId) {
-        return ResponseEntity.ok(progressService.getUserProgress(userId));
+    public ResponseEntity<List<CardProgressDTO>> getProgress(@PathVariable Long userId) {
+        return ResponseEntity.ok(
+                progressService.getUserProgress(userId)
+                        .stream()
+                        .map(CardProgressDTO::new)
+                        .toList());
     }
 
     @PostMapping
-    public ResponseEntity<CardProgress> update(@RequestParam Long userId, @RequestParam Long cardId, @RequestParam int quality) {
-        return ResponseEntity.ok(progressService.reviewCard(userId, cardId, quality));
+    public ResponseEntity<CardProgressDTO> update(@RequestParam Long userId, @RequestParam Long cardId, @RequestParam int quality) {
+        return ResponseEntity.ok(new CardProgressDTO(progressService.reviewCard(userId, cardId, quality)));
     }
 }

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/ReviewController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/ReviewController.java
@@ -1,6 +1,6 @@
 package com.joeljebitto.SpacedIn.controller;
 
-import com.joeljebitto.SpacedIn.entity.CardProgress;
+import com.joeljebitto.SpacedIn.dto.CardProgressDTO;
 import com.joeljebitto.SpacedIn.service.ProgressService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +17,7 @@ public class ReviewController {
     }
 
     @PostMapping("/cards/{cardId}/review")
-    public ResponseEntity<CardProgress> review(@PathVariable Long cardId, @RequestParam Long userId, @RequestParam int quality) {
-        return ResponseEntity.ok(progressService.reviewCard(userId, cardId, quality));
+    public ResponseEntity<CardProgressDTO> review(@PathVariable Long cardId, @RequestParam Long userId, @RequestParam int quality) {
+        return ResponseEntity.ok(new CardProgressDTO(progressService.reviewCard(userId, cardId, quality)));
     }
 }

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/controller/UserController.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.joeljebitto.SpacedIn.controller;
 
-import com.joeljebitto.SpacedIn.entity.User;
+import com.joeljebitto.SpacedIn.dto.UserDTO;
 import com.joeljebitto.SpacedIn.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,12 +15,12 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> get(@PathVariable Long id) {
-        return ResponseEntity.ok(userService.getUser(id));
+    public ResponseEntity<UserDTO> get(@PathVariable Long id) {
+        return ResponseEntity.ok(new UserDTO(userService.getUser(id)));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<User> update(@PathVariable Long id, @RequestBody User user) {
+    public ResponseEntity<UserDTO> update(@PathVariable Long id, @RequestBody UserDTO user) {
         return ResponseEntity.ok(userService.updateUser(id, user));
     }
 

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/CardProgressDTO.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/CardProgressDTO.java
@@ -1,0 +1,40 @@
+package com.joeljebitto.SpacedIn.dto;
+
+import com.joeljebitto.SpacedIn.entity.CardProgress;
+
+import java.time.LocalDate;
+
+public class CardProgressDTO {
+    private Long id;
+    private Long cardId;
+    private Long userId;
+    private double easinessFactor;
+    private int repetitions;
+    private int interval;
+    private LocalDate lastReviewed;
+    private LocalDate nextReviewDate;
+
+    public CardProgressDTO(CardProgress progress) {
+        this.id = progress.getId();
+        if (progress.getCard() != null) {
+            this.cardId = progress.getCard().getId();
+        }
+        if (progress.getUser() != null) {
+            this.userId = progress.getUser().getId();
+        }
+        this.easinessFactor = progress.getEasinessFactor();
+        this.repetitions = progress.getRepetitions();
+        this.interval = progress.getInterval();
+        this.lastReviewed = progress.getLastReviewed();
+        this.nextReviewDate = progress.getNextReviewDate();
+    }
+
+    public Long getId() { return id; }
+    public Long getCardId() { return cardId; }
+    public Long getUserId() { return userId; }
+    public double getEasinessFactor() { return easinessFactor; }
+    public int getRepetitions() { return repetitions; }
+    public int getInterval() { return interval; }
+    public LocalDate getLastReviewed() { return lastReviewed; }
+    public LocalDate getNextReviewDate() { return nextReviewDate; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/dto/UserDTO.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/dto/UserDTO.java
@@ -1,0 +1,32 @@
+package com.joeljebitto.SpacedIn.dto;
+
+import com.joeljebitto.SpacedIn.entity.Role;
+import com.joeljebitto.SpacedIn.entity.User;
+
+public class UserDTO {
+    private Long id;
+    private String username;
+    private String email;
+    private Role role;
+
+    public UserDTO() {}
+
+    public UserDTO(User user) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+        this.role = user.getRole();
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+}

--- a/Server/src/main/java/com/joeljebitto/SpacedIn/service/UserService.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/service/UserService.java
@@ -1,5 +1,6 @@
 package com.joeljebitto.SpacedIn.service;
 
+import com.joeljebitto.SpacedIn.dto.UserDTO;
 import com.joeljebitto.SpacedIn.entity.User;
 import com.joeljebitto.SpacedIn.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,11 +20,11 @@ public class UserService {
         return userRepository.findById(id).orElseThrow();
     }
 
-    public User updateUser(Long id, User userData) {
+    public UserDTO updateUser(Long id, UserDTO userData) {
         User user = getUser(id);
         user.setEmail(userData.getEmail());
         user.setUsername(userData.getUsername());
-        return userRepository.save(user);
+        return new UserDTO(userRepository.save(user));
     }
 
     public void changePassword(Long id, String newPassword) {


### PR DESCRIPTION
## Summary
- remove entity imports from controllers
- construct DTOs directly in controllers
- update `UserService.updateUser` to use `UserDTO`
- return DTO from user update endpoint

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68653e5835bc832da66ee254c6b9d3dc