### PR TITLE
Remove obsolete LOB annotations

### DIFF
--- a/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
+++ b/Server/src/main/java/com/joeljebitto/SpacedIn/entity/Flashcard.java
@@ -15,11 +15,9 @@ public class Flashcard {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @Lob
   @Column(columnDefinition = "TEXT")
   private String question;
 
-  @Lob
   @Column(columnDefinition = "TEXT")
   private String answer;
   @JsonBackReference

--- a/Server/src/main/resources/application.properties
+++ b/Server/src/main/resources/application.properties
@@ -8,5 +8,3 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 jwt.secret=2A5TsbU3mS6KjfF/B4nGzEqTVvZP/Z2oNV4JfwO0bnA=
 jwt.expiration=3600000
-# Required for PostgreSQL when using @Lob fields
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true


### PR DESCRIPTION
## Summary
- replace `@Lob` usage in Flashcard entity with `@Column(columnDefinition = "TEXT")`
- drop unused property that enabled LOB support for PostgreSQL

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6865500fdcc0832d94f328149dc8c773