### PR TITLE
Display deck title on deck page

### DIFF
--- a/SpacedIn/src/pages/Deck.jsx
+++ b/SpacedIn/src/pages/Deck.jsx
@@ -8,6 +8,7 @@ export default function Deck() {
   const { id } = useParams();
   const { user } = useAuth();
   const [stats, setStats] = useState(null);
+  const [deck, setDeck] = useState(null);
 
   const refreshStats = useCallback(() => {
     if (user?.id) {
@@ -19,6 +20,10 @@ export default function Deck() {
     refreshStats();
   }, [refreshStats]);
 
+  useEffect(() => {
+    api.getDeck(id).then(setDeck).catch(console.error);
+  }, [id]);
+
   console.log(stats);
 
   return (
@@ -26,6 +31,8 @@ export default function Deck() {
       <Link to="/dashboard" className="text-blue-600">
         Back
       </Link>
+
+      {deck && <h1 className="text-xl font-bold">{deck.title}</h1>}
 
       {stats && (
         <div className="space-y-1">

--- a/SpacedIn/src/services/api.js
+++ b/SpacedIn/src/services/api.js
@@ -32,6 +32,7 @@ export const api = {
       body: JSON.stringify(data),
     }),
   getDecks: (userId) => request(`/api/decks/user/${userId}`),
+  getDeck: (id) => request(`/api/decks/share/${id}`),
   createDeck: (userId, data) =>
     request(`/api/decks/${userId}`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- fetch deck details from backend
- show deck name on Deck page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686699f249c0832db62242f6157f5ff7